### PR TITLE
Add Custom ID getter and setter to RMCResponse

### DIFF
--- a/rmc.go
+++ b/rmc.go
@@ -131,6 +131,16 @@ type RMCResponse struct {
 	errorCode  uint32
 }
 
+// customID sets the RMC response customID
+func (response *RMCResponse) CustomID() uint16 {
+	return response.customID
+}
+
+// CustomID sets the RMC response customID
+func (response *RMCResponse) SetCustomID(customID uint16) {
+	response.customID = customID
+}
+
 // SetSuccess sets the RMCResponse payload to an instance of RMCSuccess
 func (response *RMCResponse) SetSuccess(methodID uint32, data []byte) {
 	response.success = 1

--- a/rmc.go
+++ b/rmc.go
@@ -136,7 +136,7 @@ func (response *RMCResponse) CustomID() uint16 {
 	return response.customID
 }
 
-// CustomID sets the RMC response customID
+// SetCustomID sets the RMC response customID
 func (response *RMCResponse) SetCustomID(customID uint16) {
 	response.customID = customID
 }

--- a/rmc.go
+++ b/rmc.go
@@ -131,7 +131,7 @@ type RMCResponse struct {
 	errorCode  uint32
 }
 
-// customID sets the RMC response customID
+// CustomID returns the RMC response customID
 func (response *RMCResponse) CustomID() uint16 {
 	return response.customID
 }


### PR DESCRIPTION
This pull request adds the option for setting a Custom ID to `RMCResponse`.

This allows setting a Custom ID for protocols that require it, like the `Shop` protocol, present in Pokémon Bank and Nintendo Badge Arcade