### PR TITLE
Fix RMCRequest parameters

### DIFF
--- a/rmc.go
+++ b/rmc.go
@@ -86,7 +86,7 @@ func (request *RMCRequest) FromBytes(data []byte) error {
 	}
 	callID := stream.ReadUInt32LE()
 	methodID := stream.ReadUInt32LE()
-	parameters := data[13:]
+	parameters := data[stream.Buffer.ByteOffset():]
 
 	request.protocolID = protocolID
 	request.callID = callID


### PR DESCRIPTION
Don't use a fixed value to get the parameters, as a custom ID can extend the header size and cause issues when reading the parameters. Get the offset dynamically instead.