### PR TITLE
Add WriteDateTime for clarity

### DIFF
--- a/kerberos.go
+++ b/kerberos.go
@@ -163,7 +163,7 @@ func (ticketInternalData *TicketInternalData) SetSessionKey(sessionKey []byte) {
 
 // Encrypt writes the ticket data to the provided stream and returns the encrypted byte slice
 func (ticketInternalData *TicketInternalData) Encrypt(key []byte, stream *StreamOut) []byte {
-	stream.WriteUInt64LE(ticketInternalData.timestamp.Value())
+	stream.WriteDateTime(ticketInternalData.timestamp)
 	stream.WriteUInt32LE(ticketInternalData.userPID)
 
 	// Session key is not a NEX buffer type

--- a/stream_out.go
+++ b/stream_out.go
@@ -211,6 +211,11 @@ func (stream *StreamOut) WriteDataHolder(dataholder *DataHolder) {
 	stream.WriteBytesNext(content)
 }
 
+// WriteDateTime writes a NEX DateTime type
+func (stream *StreamOut) WriteDateTime(datetime *DateTime) {
+	stream.WriteUInt64LE(datetime.value)
+}
+
 // NewStreamOut returns a new nex output stream
 func NewStreamOut(server *Server) *StreamOut {
 	return &StreamOut{


### PR DESCRIPTION
This PR adds `WriteDateTime(datetime)` in favor of using `WriteUInt64LE(datetime.Value())`.