### PR TITLE
KickAll command + "graceful" kick

### DIFF
--- a/client.go
+++ b/client.go
@@ -207,7 +207,7 @@ func (client *Client) StartTimeoutTimer() {
 		client.server.SendPing(client)
 		//if we *still* get nothing, they're gone
 		client.pingKickTimer = time.AfterFunc(time.Second*time.Duration(client.server.PingTimeout()), func() {
-			client.server.Kick(client)
+			client.server.TimeoutKick(client)
 		})
 	})
 }

--- a/server.go
+++ b/server.go
@@ -221,7 +221,6 @@ func (server *Server) ClientConnected(client *Client) bool {
 
 // Kick removes a client from the server
 func (server *Server) Kick(client *Client) {
-	// Server events expect a packet to be passed, even though this isn't really a packet event
 	var packet PacketInterface
 
 	if server.PRUDPVersion() == 0 {
@@ -229,11 +228,45 @@ func (server *Server) Kick(client *Client) {
 	} else {
 		packet, _ = NewPacketV1(client, nil)
 	}
+	packet.SetVersion(1)
+	packet.SetSource(0xA1)
+	packet.SetDestination(0xAF)
+	packet.SetType(DisconnectPacket)
+
+	packet.AddFlag(FlagReliable)
+
+	server.Send(packet)
 
 	server.Emit("Kick", packet)
 	client.SetConnected(false)
 	discriminator := client.Address().String()
 	delete(server.clients, discriminator)
+}
+
+// Kick removes a client from the server
+func (server *Server) KickAll() {
+	for _, client := range server.clients {
+		var packet PacketInterface
+
+		if server.PRUDPVersion() == 0 {
+			packet, _ = NewPacketV0(client, nil)
+		} else {
+			packet, _ = NewPacketV1(client, nil)
+		}
+		packet.SetVersion(1)
+		packet.SetSource(0xA1)
+		packet.SetDestination(0xAF)
+		packet.SetType(DisconnectPacket)
+	
+		packet.AddFlag(FlagReliable)
+	
+		server.Send(packet)
+
+		server.Emit("Kick", packet)
+		client.SetConnected(false)
+		discriminator := client.Address().String()
+		delete(server.clients, discriminator)
+	}
 }
 
 // SendPing sends a ping packet to the given client

--- a/server.go
+++ b/server.go
@@ -230,7 +230,6 @@ func (server *Server) TimeoutKick(client *Client) {
 		packet, _ = NewPacketV1(client, nil)
 		packet.SetVersion(1)
 	}
-	packet.SetVersion(1)
 	packet.SetSource(0xA1)
 	packet.SetDestination(0xAF)
 	packet.SetType(DisconnectPacket)
@@ -254,7 +253,6 @@ func (server *Server) GracefulKick(client *Client) {
 		packet, _ = NewPacketV1(client, nil)
 		packet.SetVersion(1)
 	}
-	packet.SetVersion(1)
 	packet.SetSource(0xA1)
 	packet.SetDestination(0xAF)
 	packet.SetType(DisconnectPacket)

--- a/server.go
+++ b/server.go
@@ -225,8 +225,10 @@ func (server *Server) TimeoutKick(client *Client) {
 
 	if server.PRUDPVersion() == 0 {
 		packet, _ = NewPacketV0(client, nil)
+		packet.SetVersion(0)
 	} else {
 		packet, _ = NewPacketV1(client, nil)
+		packet.SetVersion(1)
 	}
 	packet.SetVersion(1)
 	packet.SetSource(0xA1)
@@ -247,8 +249,10 @@ func (server *Server) GracefulKick(client *Client) {
 
 	if server.PRUDPVersion() == 0 {
 		packet, _ = NewPacketV0(client, nil)
+		packet.SetVersion(0)
 	} else {
 		packet, _ = NewPacketV1(client, nil)
+		packet.SetVersion(1)
 	}
 	packet.SetVersion(1)
 	packet.SetSource(0xA1)
@@ -272,10 +276,11 @@ func (server *Server) GracefulKickAll() {
 
 		if server.PRUDPVersion() == 0 {
 			packet, _ = NewPacketV0(client, nil)
+			packet.SetVersion(0)
 		} else {
 			packet, _ = NewPacketV1(client, nil)
+			packet.SetVersion(1)
 		}
-		packet.SetVersion(1)
 		packet.SetSource(0xA1)
 		packet.SetDestination(0xAF)
 		packet.SetType(DisconnectPacket)


### PR DESCRIPTION
This PR adds support for kicking all connected clients, which (combined with the next change) allows for a "graceful" disconnect that does not require waiting for the clients to timeout.

The second change adds code to send a DISCONNECT PRUDP packet that will instantly kick a given client.

Combined with code on the game server itself (or perhaps even added here?) this means that e.g. catching CTRL+C and kicking all clients is possible (useful for testing!)