### PR TITLE
Add HPP protocol support

### DIFF
--- a/hpp_packet.go
+++ b/hpp_packet.go
@@ -65,10 +65,14 @@ func (packet *HPPPacket) ValidateAccessKey() error {
 
 // ValidatePassword checks if the password signature is valid
 func (packet *HPPPacket) ValidatePassword() error {
+	if packet.sender.server.passwordFromPIDHandler == nil {
+		return errors.New("[HPP] Missing passwordFromPIDHandler!")
+	}
+
 	pid := packet.Sender().PID()
 	buffer := packet.rmcRequest.Bytes()
 
-	password := packet.sender.server.passwordFromPIDHandler(pid)
+	password, _ := packet.sender.server.passwordFromPIDHandler(pid)
 	if password == "" {
 		return errors.New("[HPP] PID does not exist")
 	}

--- a/hpp_packet.go
+++ b/hpp_packet.go
@@ -1,0 +1,115 @@
+package nex
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/md5"
+	"encoding/hex"
+	"errors"
+)
+
+// HPPPacket represents an HPP packet
+type HPPPacket struct {
+	Packet
+	accessKeySignature []byte
+	passwordSignature  []byte
+}
+
+// SetAccessKeySignature sets the packet access key signature
+func (packet *HPPPacket) SetAccessKeySignature(accessKeySignature string) {
+	accessKeySignatureBytes, err := hex.DecodeString(accessKeySignature)
+	if err != nil {
+		logger.Error("[HPP] Failed to convert AccessKeySignature to bytes")
+	}
+
+	packet.accessKeySignature = accessKeySignatureBytes
+}
+
+// AccessKeySignature returns the packet access key signature
+func (packet *HPPPacket) AccessKeySignature() []byte {
+	return packet.accessKeySignature
+}
+
+// SetPasswordSignature sets the packet password signature
+func (packet *HPPPacket) SetPasswordSignature(passwordSignature string) {
+	passwordSignatureBytes, err := hex.DecodeString(passwordSignature)
+	if err != nil {
+		logger.Error("[HPP] Failed to convert PasswordSignature to bytes")
+	}
+
+	packet.passwordSignature = passwordSignatureBytes
+}
+
+// PasswordSignature returns the packet password signature
+func (packet *HPPPacket) PasswordSignature() []byte {
+	return packet.passwordSignature
+}
+
+// ValidateAccessKey checks if the access key signature is valid
+func (packet *HPPPacket) ValidateAccessKey() error {
+	accessKey := packet.Sender().Server().AccessKey()
+	buffer := packet.rmcRequest.Bytes()
+
+	accessKeyBytes, err := hex.DecodeString(accessKey)
+	if err != nil {
+		return err
+	}
+
+	calculatedAccessKeySignature := packet.calculateSignature(buffer, accessKeyBytes)
+	if !bytes.Equal(calculatedAccessKeySignature, packet.accessKeySignature) {
+		return errors.New("[HPP] Access key signature is not valid")
+	}
+
+	return nil
+}
+
+// ValidatePassword checks if the password signature is valid
+func (packet *HPPPacket) ValidatePassword() error {
+	pid := packet.Sender().PID()
+	buffer := packet.rmcRequest.Bytes()
+
+	password := packet.sender.server.passwordFromPIDHandler(pid)
+	if password == "" {
+		return errors.New("[HPP] PID does not exist")
+	}
+
+	passwordBytes := []byte(password)
+
+	passwordSignatureKey := DeriveKerberosKey(pid, passwordBytes)
+
+	calculatedPasswordSignature := packet.calculateSignature(buffer, passwordSignatureKey)
+	if !bytes.Equal(calculatedPasswordSignature, packet.passwordSignature) {
+		return errors.New("[HPP] Password signature is invalid")
+	}
+
+	return nil
+}
+
+func (packet *HPPPacket) calculateSignature(buffer []byte, key []byte) []byte {
+	mac := hmac.New(md5.New, key)
+	mac.Write(buffer)
+	hmac := mac.Sum(nil)
+
+	return hmac
+}
+
+// NewHPPPacket returns a new HPP packet
+func NewHPPPacket(client *Client, data []byte) (*HPPPacket, error) {
+	packet := NewPacket(client, data)
+
+	hppPacket := HPPPacket{Packet: packet}
+
+	if data != nil {
+		hppPacket.payload = data
+
+		rmcRequest := NewRMCRequest()
+		err := rmcRequest.FromBytes(data)
+		if err != nil {
+			return &HPPPacket{}, errors.New("[HPP] Error parsing RMC request: " + err.Error())
+		}
+
+		hppPacket.rmcRequest = rmcRequest
+	}
+
+	return &hppPacket, nil
+}

--- a/rmc.go
+++ b/rmc.go
@@ -162,9 +162,11 @@ func (response *RMCResponse) SetError(errorCode uint32) {
 func (response *RMCResponse) Bytes() []byte {
 	body := NewStreamOut(nil)
 
-	body.WriteUInt8(response.protocolID)
-	if response.protocolID == 0x7f {
-		body.WriteUInt16LE(response.customID)
+	if response.protocolID > 0 {
+		body.WriteUInt8(response.protocolID)
+		if response.protocolID == 0x7f {
+			body.WriteUInt16LE(response.customID)
+		}
 	}
 	body.WriteUInt8(response.success)
 

--- a/server.go
+++ b/server.go
@@ -27,7 +27,7 @@ type Server struct {
 	prudpV1EventHandles        map[string][]func(*PacketV1)
 	hppEventHandles            map[string][]func(*HPPPacket)
 	hppClientResponses         map[*Client](chan []byte)
-	passwordFromPIDHandler     func(pid uint32) string
+	passwordFromPIDHandler     func(pid uint32) (string, uint32)
 	accessKey                  string
 	prudpVersion               int
 	prudpProtocolMinorVersion  int
@@ -718,9 +718,14 @@ func (server *Server) FindClientFromConnectionID(rvcid uint32) *Client {
 	return nil
 }
 
-// SetPasswordFromPIDFunction sets the function for HPP to get a NEX password using the PID
-func (server *Server) SetPasswordFromPIDFunction(handler func(pid uint32) string) {
+// SetPasswordFromPIDFunction sets the function for HPP or the auth server to get a NEX password using the PID
+func (server *Server) SetPasswordFromPIDFunction(handler func(pid uint32) (string, uint32)) {
 	server.passwordFromPIDHandler = handler
+}
+
+// PasswordFromPIDFunction returns the function for HPP or the auth server to get a NEX password using the PID
+func (server *Server) PasswordFromPIDFunction() func(pid uint32) (string, uint32) {
+	return server.passwordFromPIDHandler
 }
 
 // Send writes data to client

--- a/server.go
+++ b/server.go
@@ -12,7 +12,9 @@ import (
 	"fmt"
 	"math/rand"
 	"net"
+	"net/http"
 	"runtime"
+	"strconv"
 	"time"
 )
 
@@ -23,6 +25,9 @@ type Server struct {
 	genericEventHandles        map[string][]func(PacketInterface)
 	prudpV0EventHandles        map[string][]func(*PacketV0)
 	prudpV1EventHandles        map[string][]func(*PacketV1)
+	hppEventHandles            map[string][]func(*HPPPacket)
+	hppClientResponses         map[*Client](chan []byte)
+	passwordFromPIDHandler     func(pid uint32) string
 	accessKey                  string
 	prudpVersion               int
 	prudpProtocolMinorVersion  int
@@ -168,6 +173,121 @@ func (server *Server) handleSocketMessage() error {
 	return nil
 }
 
+// HPPListen starts a NEX HPP server on a given address
+func (server *Server) HPPListen(address string) {
+	hppHandler := func(w http.ResponseWriter, req *http.Request) {
+		if req.Method != "POST" {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		pidValue := req.Header.Get("pid")
+		if pidValue == "" {
+			logger.Error("[HPP] PID is empty")
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		token := req.Header.Get("token")
+		if token == "" {
+			logger.Error("[HPP] Token is empty")
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		accessKeySignature := req.Header.Get("signature1")
+		if accessKeySignature == "" {
+			logger.Error("[HPP] Access key signature is empty")
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		passwordSignature := req.Header.Get("signature2")
+		if passwordSignature == "" {
+			logger.Error("[HPP] Password signature is empty")
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		pid, err := strconv.Atoi(pidValue)
+		if err != nil {
+			logger.Error(err.Error())
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		rmcRequestString := req.FormValue("file")
+
+		rmcRequestBytes := []byte(rmcRequestString)
+
+		client := NewClient(nil, server)
+		client.SetPID(uint32(pid))
+
+		hppPacket, _ := NewHPPPacket(client, rmcRequestBytes)
+
+		hppPacket.SetAccessKeySignature(accessKeySignature)
+		hppPacket.SetPasswordSignature(passwordSignature)
+
+		err = hppPacket.ValidateAccessKey()
+		if err != nil {
+			logger.Error(err.Error())
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		err = hppPacket.ValidatePassword()
+		if err != nil {
+			logger.Error(err.Error())
+			rmcRequest := hppPacket.RMCRequest()
+			callID := rmcRequest.CallID()
+
+			errorResponse := NewRMCResponse(0, callID)
+			// HPP returns PythonCore::ValidationError if password is missing or invalid
+			errorResponse.SetError(Errors.PythonCore.ValidationError)
+
+			_, err = w.Write(errorResponse.Bytes())
+			if err != nil {
+				logger.Error(err.Error())
+			}
+
+			return
+		}
+
+		server.hppClientResponses[client] = make(chan []byte)
+
+		server.Emit("Data", hppPacket)
+
+		rmcResponseBytes := <- server.hppClientResponses[client]
+
+		if len(rmcResponseBytes) > 0 {
+			_, err = w.Write(rmcResponseBytes)
+			if err != nil {
+				logger.Error(err.Error())
+			}
+		}
+
+		delete(server.hppClientResponses, client)
+	}
+
+	http.HandleFunc("/hpp/", hppHandler)
+
+	quit := make(chan struct{})
+
+	go server.handleHTTP(address, quit)
+
+	logger.Success(fmt.Sprintf("HPP server listening on address - %s", address))
+
+	<-quit
+}
+
+func (server *Server) handleHTTP(address string, quit chan struct{}) {
+	err := http.ListenAndServe(address, nil)
+
+	quit <- struct{}{}
+
+	panic(err)
+}
+
 // On sets the data event handler
 func (server *Server) On(event string, handler interface{}) {
 	// Check if the handler type matches one of the allowed types, and store the handler in it's allowed property
@@ -179,6 +299,8 @@ func (server *Server) On(event string, handler interface{}) {
 		server.prudpV0EventHandles[event] = append(server.prudpV0EventHandles[event], handler)
 	case func(*PacketV1):
 		server.prudpV1EventHandles[event] = append(server.prudpV1EventHandles[event], handler)
+	case func(*HPPPacket):
+		server.hppEventHandles[event] = append(server.hppEventHandles[event], handler)
 	}
 }
 
@@ -203,6 +325,12 @@ func (server *Server) Emit(event string, packet interface{}) {
 		}
 	case *PacketV1:
 		eventName := server.prudpV1EventHandles[event]
+		for i := 0; i < len(eventName); i++ {
+			handler := eventName[i]
+			go handler(packet)
+		}
+	case *HPPPacket:
+		eventName := server.hppEventHandles[event]
 		for i := 0; i < len(eventName); i++ {
 			handler := eventName[i]
 			go handler(packet)
@@ -590,25 +718,38 @@ func (server *Server) FindClientFromConnectionID(rvcid uint32) *Client {
 	return nil
 }
 
+// SetPasswordFromPIDFunction sets the function for HPP to get a NEX password using the PID
+func (server *Server) SetPasswordFromPIDFunction(handler func(pid uint32) string) {
+	server.passwordFromPIDHandler = handler
+}
+
 // Send writes data to client
 func (server *Server) Send(packet PacketInterface) {
-	data := packet.Payload()
-	fragments := int(int16(len(data)) / server.fragmentSize)
+	switch packet := packet.(type) {
+	case *HPPPacket:
+		client := packet.Sender()
+		payload := packet.Payload()
+		server.hppClientResponses[client] <- payload
+	default:
+		data := packet.Payload()
+		fragments := int(int16(len(data)) / server.fragmentSize)
 
-	var fragmentID uint8 = 1
-	for i := 0; i <= fragments; i++ {
-		time.Sleep(time.Second / 2)
-		if int16(len(data)) < server.fragmentSize {
-			packet.SetPayload(data)
-			server.SendFragment(packet, 0)
-		} else {
-			packet.SetPayload(data[:server.fragmentSize])
-			server.SendFragment(packet, fragmentID)
+		var fragmentID uint8 = 1
+		for i := 0; i <= fragments; i++ {
+			time.Sleep(time.Second / 2)
+			if int16(len(data)) < server.fragmentSize {
+				packet.SetPayload(data)
+				server.SendFragment(packet, 0)
+			} else {
+				packet.SetPayload(data[:server.fragmentSize])
+				server.SendFragment(packet, fragmentID)
 
-			data = data[server.fragmentSize:]
-			fragmentID++
+				data = data[server.fragmentSize:]
+				fragmentID++
+			}
 		}
 	}
+
 }
 
 // SendFragment sends a packet fragment to the client
@@ -639,6 +780,8 @@ func NewServer() *Server {
 		genericEventHandles:   make(map[string][]func(PacketInterface)),
 		prudpV0EventHandles:   make(map[string][]func(*PacketV0)),
 		prudpV1EventHandles:   make(map[string][]func(*PacketV1)),
+		hppEventHandles:       make(map[string][]func(*HPPPacket)),
+		hppClientResponses:    make(map[*Client](chan []byte)),
 		clients:               make(map[string]*Client),
 		prudpVersion:          1,
 		fragmentSize:          1300,


### PR DESCRIPTION
This PR implements an HTTP server that supports HPP requests, and adds a fake packet `HPPPacket` that allows interaction with existing code on `nex-protocols-go`.

The `RMCResponse` won't write the protocol ID byte if it's set to zero. This allows support for HPP, as the RMC responses of this protocol don't include the protocol ID.

### Notes
- The server has been implemented to replicate the original behavior as accurate as possible (for example, the `token` header is required but it can have any value)
- For implementing HPP, we need to access the password of a PID to validate a request, so I added a `passwordFromPIDHandler` to get the password from there. I'd like to get a better idea on how to handle this though, since it can be confused with the `passwordFromPIDHandler` from `nex-protocols-common-go` (maybe remove it from the common protocols and make it use this one?). I'm open to suggestions. 
- A channel `hppClientResponses` is implemented to the `Server` structure. This is done to handle the HTTP responses and write the response to the correct `Client` when calling `Send()`.
- The `RMCResponse` won't write the protocol ID byte if it's set to zero. This allows support for HPP, as the RMC responses of this protocol don't include the protocol ID.
- An example server implementation can be found [here](https://github.com/DaniElectra/swapdoodle). The repository has nothing implemented, I just used it for testing the protocol.
- When making an HPP response, it should be done the following way:
```go
// The Protocol ID must be set to 0 so that it isn't written
rmcResponse := nex.NewRMCResponse(0, request.CallID())
/* Insert success or failure and parameters */

rmcResponseBytes := rmcResponse.Bytes()

responsePacket, _ := nex.NewHPPPacket(client, nil)

responsePacket.SetPayload(rmcResponseBytes)

globals.NEXServer.Send(responsePacket)
```