### PR TITLE
Fix various DataHolder issues

### DIFF
--- a/stream_out.go
+++ b/stream_out.go
@@ -214,7 +214,7 @@ func (stream *StreamOut) WriteListResult(results []*Result) {
 
 // WriteDataHolder writes a NEX DataHolder type
 func (stream *StreamOut) WriteDataHolder(dataholder *DataHolder) {
-	content := dataholder.Bytes(stream)
+	content := dataholder.Bytes(NewStreamOut(stream.Server))
 	stream.Grow(int64(len(content)))
 	stream.WriteBytesNext(content)
 }

--- a/types.go
+++ b/types.go
@@ -101,22 +101,16 @@ func (dataHolder *DataHolder) ExtractFromStream(stream *StreamIn) error {
 		return errors.New(message)
 	}
 
-	newObjectInstance := reflect.New(reflect.TypeOf(dataType).Elem()).Interface().(StructureInterface)
-
-	dataHolder.objectData, _ = stream.ReadStructure(newObjectInstance)
+	dataHolder.objectData, _ = stream.ReadStructure(dataType)
 
 	return nil
 }
 
 // Bytes encodes the DataHolder and returns a byte array
 func (dataHolder *DataHolder) Bytes(stream *StreamOut) []byte {
-	parents := dataHolder.objectData.Hierarchy()
-
-	content := []byte{}
-	for _, parent := range parents {
-		content = append(content, parent.Bytes(NewStreamOut(stream.Server))...)
-	}
-	content = append(content, dataHolder.objectData.Bytes(NewStreamOut(stream.Server))...)
+	contentStream := NewStreamOut(stream.Server)
+	contentStream.WriteStructure(dataHolder.objectData)
+	content := contentStream.Bytes()
 
 	/*
 		Technically this way of encoding a DataHolder is "wrong".


### PR DESCRIPTION
While the hierarchy implementation from #27 works in some cases, it has two problems:

- It only works for NEX version <3.5, as we aren't writing the stucture header. This isn't exactly a problem of the PR, as it was already wrong.
- It only checks for one layer of hierarchy, because there is no recursion applied.

Solve this by using `WriteStructure()` instead of getting the raw bytes, since the object data is already a `StructureInterface`.

On `ExtractFromStream()` there is no need to use reflect as the object data will be the correct structure. Using reflect also breaks with hierarchy for unknown reasons, so just pass the dataType to `ReadStructure()`.

Also fix a bug where the data holder is written twice when calling `WriteDataHolder()` because of reusing the same stream on `dataHolder.Bytes()`.

This has been tested with HPP and fake data. The data holder reads have been tested by decoding the StreamOut internally on the server.

Before:

![image](https://github.com/PretendoNetwork/nex-go/assets/112760654/852930a1-1ab7-4c71-8918-720f5164b372)


After: 

![image](https://github.com/PretendoNetwork/nex-go/assets/112760654/fab3d3fd-69ef-4863-9bf5-79725ee2ca44)
