### PR TITLE
Use structure.Copy() on DataHolder read

### DIFF
--- a/client.go
+++ b/client.go
@@ -163,12 +163,12 @@ func (client *Client) PID() uint32 {
 	return client.pid
 }
 
-// SetLocalStationURL sets the clients Local Station URL
+// SetStationURLs sets the clients Station URLs
 func (client *Client) SetStationURLs(stationURLs []string) {
 	client.stationURLs = stationURLs
 }
 
-// LocalStationURL returns the clients Local Station URL
+// StationURLs returns the clients Station URLs
 func (client *Client) StationURLs() []string {
 	return client.stationURLs
 }

--- a/stream_in.go
+++ b/stream_in.go
@@ -308,7 +308,7 @@ func (stream *StreamIn) ReadListStructure(structure StructureInterface) (interfa
 	structureSlice := reflect.MakeSlice(reflect.SliceOf(structureType), 0, int(length))
 
 	for i := 0; i < int(length); i++ {
-		newStructure := reflect.New(reflect.TypeOf(structure).Elem()).Interface().(StructureInterface)
+		newStructure := structure.Copy()
 
 		extractedStructure, err := stream.ReadStructure(newStructure)
 		if err != nil {

--- a/types.go
+++ b/types.go
@@ -118,7 +118,9 @@ func (dataHolder *DataHolder) ExtractFromStream(stream *StreamIn) error {
 		return errors.New(message)
 	}
 
-	dataHolder.objectData, _ = stream.ReadStructure(dataType)
+	newObjectInstance := dataType.Copy()
+
+	dataHolder.objectData, _ = stream.ReadStructure(newObjectInstance)
 
 	return nil
 }


### PR DESCRIPTION
This prevents issues where two clients send a packet with a same data holder and create conflicts upon writing the structure data.

Also apply newStructure.Copy() on ReadListStructure() and fix comments issues