### PR TITLE
Add Bytes() to Variant and implement ReadMap() and WriteMap()

### DIFF
--- a/rmc.go
+++ b/rmc.go
@@ -86,7 +86,7 @@ func (request *RMCRequest) FromBytes(data []byte) error {
 	}
 	callID := stream.ReadUInt32LE()
 	methodID := stream.ReadUInt32LE()
-	parameters := data[stream.Buffer.ByteOffset():]
+	parameters := data[stream.ByteOffset():]
 
 	request.protocolID = protocolID
 	request.callID = callID

--- a/stream_in.go
+++ b/stream_in.go
@@ -146,8 +146,11 @@ func (stream *StreamIn) ReadMap(keyFunction interface{}, valueFunction interface
 		TODO: Make this not suck
 
 		Map types can have any type as the key and any type as the value
-		Due to strict typing we cannot just pass stream functions as these values and call them
-		At the moment this just reads what type you want from the interface{} function type
+		To handle reading the keys and values in a generic way, we use reflect
+		to call the key and value functions, as the StreamIn read functions are
+		usually structured the same way (no input and one output). However, this
+		is not always the case (like on ReadStructure), but currently we are not
+		aware of any real cases that require those types.
 	*/
 
 	length := stream.ReadUInt32LE()
@@ -156,20 +159,31 @@ func (stream *StreamIn) ReadMap(keyFunction interface{}, valueFunction interface
 	for i := 0; i < int(length); i++ {
 		var key interface{}
 		var value interface{}
-		var err error
 
-		switch keyFunction.(type) {
-		case func() (string, error):
-			key, err = stream.ReadString()
+		keyFunctionValue := reflect.ValueOf(keyFunction)
+		keyArguments := make([]reflect.Value, 0)
+		keyOut := keyFunctionValue.Call(keyArguments)
+		key = keyOut[0].Interface()
+
+		if len(keyOut) > 1 {
+			err := keyOut[1]
+
+			if err.Interface() != nil {
+				return nil, err.Interface().(error)
+			}
 		}
 
-		if err != nil {
-			return nil, err
-		}
+		valueFunctionValue := reflect.ValueOf(valueFunction)
+		valueArguments := make([]reflect.Value, 0)
+		valueOut := valueFunctionValue.Call(valueArguments)
+		value = valueOut[0].Interface()
 
-		switch valueFunction.(type) {
-		case func() interface{}:
-			value = stream.ReadVariant()
+		if len(valueOut) > 1 {
+			err := valueOut[1]
+
+			if err.Interface() != nil {
+				return nil, err.Interface().(error)
+			}
 		}
 
 		newMap[key] = value

--- a/stream_in.go
+++ b/stream_in.go
@@ -49,9 +49,19 @@ func (stream *StreamIn) ReadUInt64LE() uint64 {
 	return stream.ReadU64LENext(1)[0]
 }
 
+// ReadInt64LE reads a int64
+func (stream *StreamIn) ReadInt64LE() int64 {
+	return int64(stream.ReadU64LENext(1)[0])
+}
+
 // ReadUInt64BE reads a uint64
 func (stream *StreamIn) ReadUInt64BE() uint64 {
 	return stream.ReadU64BENext(1)[0]
+}
+
+// ReadFloat64LE reads a int64
+func (stream *StreamIn) ReadFloat64LE() float64 {
+	return stream.ReadF64LENext(1)[0]
 }
 
 // ReadString reads and returns a nex string type

--- a/stream_out.go
+++ b/stream_out.go
@@ -236,15 +236,9 @@ func (stream *StreamOut) WriteVariant(variant *Variant) {
 }
 
 // WriteMap writes a Map type with the given key and value types
-func (stream *StreamOut) WriteMap(mapType interface{}, keyFunction interface{}, valueFunction interface{}) {
-	/*
-		TODO: Make this not suck
-
-		Map types can have any type as the key and any type as the value
-		To handle writing the keys and values in a generic way, we use reflect
-		to call the key and value functions, as the StreamOut write functions are
-		structured the same way (one input and no output).
-	*/
+func (stream *StreamOut) WriteMap(mapType interface{}) {
+	// TODO:
+	// Find a better solution that doesn't use reflect
 
 	mapValue := reflect.ValueOf(mapType)
 	count := mapValue.Len()
@@ -254,14 +248,18 @@ func (stream *StreamOut) WriteMap(mapType interface{}, keyFunction interface{}, 
 	mapIter := mapValue.MapRange()
 
 	for mapIter.Next() {
-		key := mapIter.Key()
-		value := mapIter.Value()
+		key := mapIter.Key().Interface()
+		value := mapIter.Value().Interface()
 
-		keyFunctionValue := reflect.ValueOf(keyFunction)
-		_ = keyFunctionValue.Call([]reflect.Value{key})
+		switch key := key.(type) {
+		case string:
+			stream.WriteString(key)
+		}
 
-		valueFunctionValue := reflect.ValueOf(valueFunction)
-		_ = valueFunctionValue.Call([]reflect.Value{value})
+		switch value := value.(type) {
+		case *Variant:
+			stream.WriteVariant(value)
+		}
 	}
 }
 

--- a/stream_out.go
+++ b/stream_out.go
@@ -58,6 +58,12 @@ func (stream *StreamOut) WriteInt64LE(s64 int64) {
 	stream.WriteU64LENext([]uint64{uint64(s64)})
 }
 
+// WriteFloat64LE writes a float64 as LE
+func (stream *StreamOut) WriteFloat64LE(f64 float64) {
+	stream.Grow(8)
+	stream.WriteF64LENext([]float64{f64})
+}
+
 // WriteString writes a NEX string type
 func (stream *StreamOut) WriteString(str string) {
 	str = str + "\x00"


### PR DESCRIPTION
Maps were not completely implemented before and we only had the ability
to read them from streams. In order to support every stream type on
maps, let the structure define the read or write function to call for the key
and value.

Since we have to allow every function type, pass the functions as
`interface{}` and call them using reflect. Note that ReadMap() currently
does not support every stream type, like structures, because we would
have to get the structure we want to read and pass it as an argument
when making the call.

This also requires adding various stream types, like `ReadFloat64LE()` to
`StreamIn` and other required functions for the `Variant`.

This functionality has been tested with HPP and fake data using
`MatchmakeParam`.