### PR TITLE
Use string for registering data holders

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/PretendoNetwork/nex-go
 go 1.18
 
 require (
-	github.com/PretendoNetwork/plogger-go v1.0.3
+	github.com/PretendoNetwork/plogger-go v1.0.4
 	github.com/superwhiskers/crunch/v3 v3.5.7
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/PretendoNetwork/plogger-go v1.0.3 h1:KEnrUfPaCn0LFweg8OrhtiDhlN3pclWpNhlmAtmgfB0=
-github.com/PretendoNetwork/plogger-go v1.0.3/go.mod h1:7kD6M4vPq1JL4LTuPg6kuB1OvUBOwQOtAvTaUwMbwvU=
+github.com/PretendoNetwork/plogger-go v1.0.4 h1:PF7xHw9eDRHH+RsAP9tmAE7fG0N0p6H4iPwHKnsoXwc=
+github.com/PretendoNetwork/plogger-go v1.0.4/go.mod h1:7kD6M4vPq1JL4LTuPg6kuB1OvUBOwQOtAvTaUwMbwvU=
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
 github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBDUSsw=
 github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=

--- a/kerberos.go
+++ b/kerberos.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"crypto/hmac"
 	"crypto/md5"
+	"crypto/rand"
 	"crypto/rc4"
 	"fmt"
-	"math/rand"
 )
 
 // KerberosEncryption is used to encrypt/decrypt using Kerberos
@@ -178,7 +178,10 @@ func (ticketInternalData *TicketInternalData) Encrypt(key []byte, stream *Stream
 
 	if stream.Server.KerberosTicketVersion() == 1 {
 		ticketKey := make([]byte, 16)
-		rand.Read(ticketKey)
+		_, err := rand.Read(ticketKey)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to generate ticket key. %s", err.Error())
+		}
 
 		finalKey := MD5Hash(append(key, ticketKey...))
 

--- a/server.go
+++ b/server.go
@@ -9,8 +9,8 @@
 package nex
 
 import (
+	"crypto/rand"
 	"fmt"
-	"math/rand"
 	"net"
 	"net/http"
 	"runtime"
@@ -534,7 +534,12 @@ func (server *Server) AcknowledgePacket(packet PacketInterface, payload []byte) 
 
 		if packet.Type() == SynPacket {
 			serverConnectionSignature := make([]byte, 16)
-			rand.Read(serverConnectionSignature)
+			_, err := rand.Read(serverConnectionSignature)
+			if err != nil {
+				// TODO - Should this return the error too?
+				logger.Error(err.Error())
+				return
+			}
 
 			ackPacket.Sender().SetServerConnectionSignature(serverConnectionSignature)
 			ackPacket.SetConnectionSignature(serverConnectionSignature)

--- a/types.go
+++ b/types.go
@@ -103,12 +103,8 @@ func NewData() *Data {
 var dataHolderKnownObjects = make(map[string]StructureInterface)
 
 // RegisterDataHolderType registers a structure to be a valid type in the DataHolder structure
-func RegisterDataHolderType(structure StructureInterface) {
-	_, name, found := strings.Cut(fmt.Sprintf("%T", structure), ".")
-
-	if found {
-		dataHolderKnownObjects[name] = structure
-	}
+func RegisterDataHolderType(name string, structure StructureInterface) {
+	dataHolderKnownObjects[name] = structure
 }
 
 // DataHolder represents a structure which can hold any other structure

--- a/types.go
+++ b/types.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"reflect"
 	"strings"
 	"time"
 )
@@ -105,8 +104,11 @@ var dataHolderKnownObjects = make(map[string]StructureInterface)
 
 // RegisterDataHolderType registers a structure to be a valid type in the DataHolder structure
 func RegisterDataHolderType(structure StructureInterface) {
-	name := reflect.TypeOf(structure).Elem().Name()
-	dataHolderKnownObjects[name] = structure
+	_, name, found := strings.Cut(fmt.Sprintf("%T", structure), ".")
+
+	if found {
+		dataHolderKnownObjects[name] = structure
+	}
 }
 
 // DataHolder represents a structure which can hold any other structure


### PR DESCRIPTION
This allows us to reduce usage of reflect.

Also replace math/rand with crypto/rand, and implement
error handling for `rand.Read()`