### PR TITLE
Stability - Better concurrent map API and deferred packet handling

### DIFF
--- a/client.go
+++ b/client.go
@@ -157,7 +157,6 @@ func (client *Client) SequenceIDCounterOut() *Counter {
 }
 
 // SequenceIDCounterIn returns the clients packet SequenceID counter for incoming packets
-// TODO - Rename this? This name kinda sucks now that it's being used for deferred packet handling
 func (client *Client) SequenceIDCounterIn() *Counter {
 	return client.sequenceIDIn
 }

--- a/client.go
+++ b/client.go
@@ -235,6 +235,18 @@ func (client *Client) StartTimeoutTimer() {
 	})
 }
 
+// StopTimeoutTimer stops the packet timeout timer
+func (client *Client) StopTimeoutTimer() {
+	//Stop the kick timer
+	if client.pingKickTimer != nil {
+		client.pingKickTimer.Stop()
+	}
+	//and the check timer
+	if client.pingCheckTimer != nil {
+		client.pingCheckTimer.Stop()
+	}
+}
+
 // NewClient returns a new PRUDP client
 func NewClient(address *net.UDPAddr, server *Server) *Client {
 	client := &Client{

--- a/client.go
+++ b/client.go
@@ -21,7 +21,7 @@ type Client struct {
 	clientConnectionSignature []byte
 	sessionKey                []byte
 	sequenceIDIn              *Counter
-	sequenceIDOut             *Counter
+	sequenceIDOutManager      *SequenceIDManager
 	pid                       uint32
 	stationURLs               []*StationURL
 	connectionID              uint32
@@ -34,7 +34,7 @@ type Client struct {
 // Reset resets the Client to default values
 func (client *Client) Reset() error {
 	client.sequenceIDIn = NewCounter(0)
-	client.sequenceIDOut = NewCounter(0)
+	client.sequenceIDOutManager = NewSequenceIDManager() // TODO - Pass the server into here to get data for multiple substreams and the unreliable starting ID
 	client.incomingPacketManager = NewPacketManager()
 
 	client.UpdateAccessKey(client.Server().AccessKey())
@@ -151,9 +151,9 @@ func (client *Client) ClientConnectionSignature() []byte {
 	return client.clientConnectionSignature
 }
 
-// SequenceIDCounterOut returns the clients packet SequenceID counter for out-going packets
-func (client *Client) SequenceIDCounterOut() *Counter {
-	return client.sequenceIDOut
+// SequenceIDOutManager returns the clients packet SequenceID manager for out-going packets
+func (client *Client) SequenceIDOutManager() *SequenceIDManager {
+	return client.sequenceIDOutManager
 }
 
 // SequenceIDCounterIn returns the clients packet SequenceID counter for incoming packets

--- a/client.go
+++ b/client.go
@@ -28,12 +28,14 @@ type Client struct {
 	pingCheckTimer            *time.Timer
 	pingKickTimer             *time.Timer
 	connected                 bool
+	incomingPacketManager     *PacketManager
 }
 
 // Reset resets the Client to default values
 func (client *Client) Reset() error {
 	client.sequenceIDIn = NewCounter(0)
 	client.sequenceIDOut = NewCounter(0)
+	client.incomingPacketManager = NewPacketManager()
 
 	client.UpdateAccessKey(client.Server().AccessKey())
 	err := client.UpdateRC4Key([]byte("CD&ML"))
@@ -155,6 +157,7 @@ func (client *Client) SequenceIDCounterOut() *Counter {
 }
 
 // SequenceIDCounterIn returns the clients packet SequenceID counter for incoming packets
+// TODO - Rename this? This name kinda sucks now that it's being used for deferred packet handling
 func (client *Client) SequenceIDCounterIn() *Counter {
 	return client.sequenceIDIn
 }

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.18
 require (
 	github.com/PretendoNetwork/plogger-go v1.0.4
 	github.com/superwhiskers/crunch/v3 v3.5.7
+	golang.org/x/exp v0.0.0-20230905200255-921286631fa9
 	golang.org/x/mod v0.12.0
 )
 
@@ -13,6 +14,6 @@ require (
 	github.com/jwalton/go-supportscolor v1.2.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.19 // indirect
-	golang.org/x/sys v0.11.0 // indirect
+	golang.org/x/sys v0.12.0 // indirect
 	golang.org/x/term v0.11.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -2,7 +2,7 @@ github.com/PretendoNetwork/plogger-go v1.0.4 h1:PF7xHw9eDRHH+RsAP9tmAE7fG0N0p6H4
 github.com/PretendoNetwork/plogger-go v1.0.4/go.mod h1:7kD6M4vPq1JL4LTuPg6kuB1OvUBOwQOtAvTaUwMbwvU=
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
 github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBDUSsw=
-github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
+github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/jwalton/go-supportscolor v1.2.0 h1:g6Ha4u7Vm3LIsQ5wmeBpS4gazu0UP1DRDE8y6bre4H8=
 github.com/jwalton/go-supportscolor v1.2.0/go.mod h1:hFVUAZV2cWg+WFFC4v8pT2X/S2qUUBYMioBD9AINXGs=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
@@ -12,14 +12,16 @@ github.com/mattn/go-isatty v0.0.19 h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APP
 github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/superwhiskers/crunch/v3 v3.5.7 h1:N9RLxaR65C36i26BUIpzPXGy2f6pQ7wisu2bawbKNqg=
 github.com/superwhiskers/crunch/v3 v3.5.7/go.mod h1:4ub2EKgF1MAhTjoOCTU4b9uLMsAweHEa89aRrfAypXA=
+golang.org/x/exp v0.0.0-20230905200255-921286631fa9 h1:GoHiUyI/Tp2nVkLI2mCxVkOjsbSXD66ic0XW0js0R9g=
+golang.org/x/exp v0.0.0-20230905200255-921286631fa9/go.mod h1:S2oDrQGGwySpoQPVqRShND87VCbxmc6bL1Yd2oYrm6k=
 golang.org/x/mod v0.12.0 h1:rmsUpXtvNzj340zd98LZ4KntptpfRHwpFOHG188oHXc=
 golang.org/x/mod v0.12.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210220050731-9a76102bfb43/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.11.0 h1:eG7RXZHdqOJ1i+0lgLgCpSXAp6M3LYlAo6osgSi0xOM=
-golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.12.0 h1:CM0HF96J0hcLAwsHPJZjfdNzs0gftsLfgKt57wWHJ0o=
+golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.11.0 h1:F9tnn/DA/Im8nCwm+fX+1/eBwi4qFjRT++MhtVC4ZX0=
 golang.org/x/term v0.11.0/go.mod h1:zC9APTIj3jG3FdV/Ons+XE1riIZXG4aZ4GTHiPZJPIU=

--- a/mutex_map.go
+++ b/mutex_map.go
@@ -42,6 +42,17 @@ func (m *MutexMap[K, V]) Size() int {
 	return len(m.real)
 }
 
+// Each runs a function for every item in the map
+// the function takes in the items key and value
+func (m *MutexMap[K, V]) Each(callback func(key K, value V)) {
+	m.RLock()
+	defer m.RUnlock()
+
+	for key, value := range m.real {
+		callback(key, value)
+	}
+}
+
 // NewMutexMap returns a new instance of MutexMap with the provided key/value types
 func NewMutexMap[K comparable, V any]() *MutexMap[K, V] {
 	return &MutexMap[K, V]{

--- a/mutex_map.go
+++ b/mutex_map.go
@@ -1,0 +1,51 @@
+package nex
+
+import "sync"
+
+// MutexMap implements a map type with go routine safe accessors through mutex locks. Embeds sync.RWMutex
+type MutexMap[K comparable, V any] struct {
+	*sync.RWMutex
+	real map[K]V
+}
+
+// Set sets a key to a given value
+func (m *MutexMap[K, V]) Set(key K, value V) {
+	m.Lock()
+	defer m.Unlock()
+
+	m.real[key] = value
+}
+
+// Get returns the given key value and a bool if found
+func (m *MutexMap[K, V]) Get(key K) (V, bool) {
+	m.RLock()
+	defer m.RUnlock()
+
+	value, ok := m.real[key]
+
+	return value, ok
+}
+
+// Delete removes a key from the internal map
+func (m *MutexMap[K, V]) Delete(key K) {
+	m.Lock()
+	defer m.Unlock()
+
+	delete(m.real, key)
+}
+
+// Size returns the length of the internal map
+func (m *MutexMap[K, V]) Size() int {
+	m.RLock()
+	defer m.RUnlock()
+
+	return len(m.real)
+}
+
+// NewMutexMap returns a new instance of MutexMap with the provided key/value types
+func NewMutexMap[K comparable, V any]() *MutexMap[K, V] {
+	return &MutexMap[K, V]{
+		RWMutex: &sync.RWMutex{},
+		real:    make(map[K]V),
+	}
+}

--- a/packet_interface.go
+++ b/packet_interface.go
@@ -2,6 +2,7 @@ package nex
 
 // PacketInterface implements all Packet methods
 type PacketInterface interface {
+	Data() []byte
 	Sender() *Client
 	SetVersion(version uint8)
 	Version() uint8

--- a/packet_interface.go
+++ b/packet_interface.go
@@ -28,6 +28,7 @@ type PacketInterface interface {
 	FragmentID() uint8
 	SetPayload(payload []byte)
 	Payload() []byte
+	DecryptPayload() error
 	RMCRequest() RMCRequest
 	Bytes() []byte
 }

--- a/packet_manager.go
+++ b/packet_manager.go
@@ -1,0 +1,43 @@
+package nex
+
+// PacketManager implements an API for pushing/popping packets in the correct order
+type PacketManager struct {
+	currentSequenceID *Counter
+	packets           []PacketInterface
+}
+
+// Next gets the next packet in the sequence. Returns nil if the next packet has not been sent yet
+func (p *PacketManager) Next() PacketInterface {
+	var packet PacketInterface
+
+	for i := 0; i < len(p.packets); i++ {
+		if p.currentSequenceID.Value() == uint32(p.packets[i].SequenceID()) {
+			packet = p.packets[i]
+			p.RemoveByIndex(i)
+			p.currentSequenceID.Increment()
+			break
+		}
+	}
+
+	return packet
+}
+
+// Push adds a packet to the pool to choose from in Next
+func (p *PacketManager) Push(packet PacketInterface) {
+	p.packets = append(p.packets, packet)
+}
+
+// RemoveByIndex removes a packet from the pool using it's index in the slice
+func (p *PacketManager) RemoveByIndex(i int) {
+	// * https://stackoverflow.com/a/37335777
+	p.packets[i] = p.packets[len(p.packets)-1]
+	p.packets = p.packets[:len(p.packets)-1]
+}
+
+// NewPacketManager returns a new PacketManager
+func NewPacketManager() *PacketManager {
+	return &PacketManager{
+		currentSequenceID: NewCounter(0),
+		packets:           make([]PacketInterface, 0),
+	}
+}

--- a/packet_resend_manager.go
+++ b/packet_resend_manager.go
@@ -1,6 +1,7 @@
 package nex
 
 import (
+	"fmt"
 	"time"
 )
 
@@ -28,11 +29,13 @@ func (p *PendingPacket) BeginTimeoutTimer() {
 
 				if int(p.iterations.Increment()) > p.maxIterations {
 					// * Max iterations hit. Assume client is dead
+					fmt.Println("Max iterations hit. Assume client is dead")
 					server.TimeoutKick(client)
 					p.StopTimeoutTimer()
 					return
 				} else {
 					// * Resend the packet
+					fmt.Printf("Time out on port %d, resend packet sequenceID %d. Iteration %d\n", p.packet.Sender().Server().port, p.packet.SequenceID(), p.iterations.Value())
 					server.SendRaw(client.Address(), p.packet.Bytes())
 				}
 			}
@@ -42,6 +45,7 @@ func (p *PendingPacket) BeginTimeoutTimer() {
 
 // StopTimeoutTimer stops the packet retransmission timer
 func (p *PendingPacket) StopTimeoutTimer() {
+	fmt.Printf("Stopping timer, packet %d was ACKED on port %d\n", p.packet.SequenceID(), p.packet.Sender().Server().port)
 	close(p.quit)
 	p.ticker.Stop()
 }

--- a/packet_resend_manager.go
+++ b/packet_resend_manager.go
@@ -23,7 +23,6 @@ func (p *PendingPacket) BeginTimeoutTimer() {
 		for {
 			select {
 			case <-p.quit:
-				//fmt.Println("Stopped")
 				return
 			case <-p.ticker.C:
 				client := p.packet.Sender()

--- a/packet_resend_manager.go
+++ b/packet_resend_manager.go
@@ -1,0 +1,99 @@
+package nex
+
+import (
+	"time"
+)
+
+// PendingPacket represents a packet which the server has sent but not received an ACK for
+// it handles it's own retransmission on a per-packet timer
+type PendingPacket struct {
+	ticker        *time.Ticker
+	quit          chan struct{}
+	packet        PacketInterface
+	iterations    *Counter
+	maxIterations int
+}
+
+// BeginTimeoutTimer starts the pending packets timeout timer until it is either stopped or maxIterations is hit
+func (p *PendingPacket) BeginTimeoutTimer() {
+	go func() {
+		for {
+			select {
+			case <-p.quit:
+				//fmt.Println("Stopped")
+				return
+			case <-p.ticker.C:
+				client := p.packet.Sender()
+				server := client.Server()
+
+				if int(p.iterations.Increment()) > p.maxIterations {
+					// * Max iterations hit. Assume client is dead
+					server.TimeoutKick(client)
+					p.StopTimeoutTimer()
+					return
+				} else {
+					// * Resend the packet
+					server.SendRaw(client.Address(), p.packet.Bytes())
+				}
+			}
+		}
+	}()
+}
+
+// StopTimeoutTimer stops the packet retransmission timer
+func (p *PendingPacket) StopTimeoutTimer() {
+	close(p.quit)
+	p.ticker.Stop()
+}
+
+// NewPendingPacket returns a new PendingPacket
+func NewPendingPacket(packet PacketInterface, timeoutTime time.Duration, maxIterations int) *PendingPacket {
+	p := &PendingPacket{
+		ticker:        time.NewTicker(timeoutTime),
+		quit:          make(chan struct{}),
+		packet:        packet,
+		iterations:    NewCounter(0),
+		maxIterations: maxIterations,
+	}
+
+	return p
+}
+
+// PacketResendManager manages all the pending packets sent the client waiting to be ACKed
+type PacketResendManager struct {
+	pending       *MutexMap[uint16, *PendingPacket]
+	timeoutTime   time.Duration
+	maxIterations int
+}
+
+// Add creates a PendingPacket, adds it to the pool, and begins it's timeout timer
+func (p *PacketResendManager) Add(packet PacketInterface) {
+	cached := NewPendingPacket(packet, p.timeoutTime, p.maxIterations)
+	p.pending.Set(packet.SequenceID(), cached)
+
+	cached.BeginTimeoutTimer()
+}
+
+// Remove removes a packet from pool and stops it's timer
+func (p *PacketResendManager) Remove(sequenceID uint16) {
+	if cached, ok := p.pending.Get(sequenceID); ok {
+		cached.StopTimeoutTimer()
+		p.pending.Delete(sequenceID)
+	}
+}
+
+// Clear removes all packets from pool and stops their timers
+func (p *PacketResendManager) Clear() {
+	p.pending.Each(func(key uint16, value *PendingPacket) {
+		p.Remove(value.packet.SequenceID())
+	})
+}
+
+// NewPacketResendManager returns a new PacketResendManager
+func NewPacketResendManager(timeoutTime time.Duration, maxIterations int) *PacketResendManager {
+	return &PacketResendManager{
+		pending:       NewMutexMap[uint16, *PendingPacket](),
+		timeoutTime:   timeoutTime,
+		maxIterations: maxIterations,
+	}
+}

--- a/packet_v0.go
+++ b/packet_v0.go
@@ -162,27 +162,27 @@ func (packet *PacketV0) DecryptPayload() error {
 
 // Bytes encodes the packet and returns a byte array
 func (packet *PacketV0) Bytes() []byte {
-	if packet.Type() == DataPacket {
-
-		if packet.HasFlag(FlagAck) {
-			packet.SetPayload([]byte{})
-		} else {
-			payload := packet.Payload()
-
-			if payload != nil || len(payload) > 0 {
-				payloadSize := len(payload)
-
-				encrypted := make([]byte, payloadSize)
-				packet.Sender().Cipher().XORKeyStream(encrypted, payload)
-
-				packet.SetPayload(encrypted)
-			}
-		}
-
-		if !packet.HasFlag(FlagHasSize) {
-			packet.AddFlag(FlagHasSize)
-		}
-	}
+	//if packet.Type() == DataPacket {
+	//
+	//	if packet.HasFlag(FlagAck) {
+	//		packet.SetPayload([]byte{})
+	//	} else {
+	//		payload := packet.Payload()
+	//
+	//		if payload != nil || len(payload) > 0 {
+	//			payloadSize := len(payload)
+	//
+	//			encrypted := make([]byte, payloadSize)
+	//			packet.Sender().Cipher().XORKeyStream(encrypted, payload)
+	//
+	//			packet.SetPayload(encrypted)
+	//		}
+	//	}
+	//
+	//	if !packet.HasFlag(FlagHasSize) {
+	//		packet.AddFlag(FlagHasSize)
+	//	}
+	//}
 
 	var typeFlags uint16 = packet.Type() | packet.Flags()<<4
 

--- a/packet_v0.go
+++ b/packet_v0.go
@@ -162,28 +162,6 @@ func (packet *PacketV0) DecryptPayload() error {
 
 // Bytes encodes the packet and returns a byte array
 func (packet *PacketV0) Bytes() []byte {
-	//if packet.Type() == DataPacket {
-	//
-	//	if packet.HasFlag(FlagAck) {
-	//		packet.SetPayload([]byte{})
-	//	} else {
-	//		payload := packet.Payload()
-	//
-	//		if payload != nil || len(payload) > 0 {
-	//			payloadSize := len(payload)
-	//
-	//			encrypted := make([]byte, payloadSize)
-	//			packet.Sender().Cipher().XORKeyStream(encrypted, payload)
-	//
-	//			packet.SetPayload(encrypted)
-	//		}
-	//	}
-	//
-	//	if !packet.HasFlag(FlagHasSize) {
-	//		packet.AddFlag(FlagHasSize)
-	//	}
-	//}
-
 	var typeFlags uint16 = packet.Type() | packet.Flags()<<4
 
 	stream := NewStreamOut(packet.Sender().Server())

--- a/packet_v1.go
+++ b/packet_v1.go
@@ -231,25 +231,6 @@ func (packet *PacketV1) DecryptPayload() error {
 
 // Bytes encodes the packet and returns a byte array
 func (packet *PacketV1) Bytes() []byte {
-	//if packet.Type() == DataPacket {
-	//	if !packet.HasFlag(FlagMultiAck) {
-	//		payload := packet.Payload()
-	//
-	//		if payload != nil || len(payload) > 0 {
-	//			payloadSize := len(payload)
-	//
-	//			encrypted := make([]byte, payloadSize)
-	//			packet.Sender().Cipher().XORKeyStream(encrypted, payload)
-	//
-	//			packet.SetPayload(encrypted)
-	//		}
-	//	}
-	//
-	//	if !packet.HasFlag(FlagHasSize) {
-	//		packet.AddFlag(FlagHasSize)
-	//	}
-	//}
-
 	var typeFlags uint16 = packet.Type() | packet.Flags()<<4
 
 	stream := NewStreamOut(packet.Sender().Server())

--- a/packet_v1.go
+++ b/packet_v1.go
@@ -231,24 +231,24 @@ func (packet *PacketV1) DecryptPayload() error {
 
 // Bytes encodes the packet and returns a byte array
 func (packet *PacketV1) Bytes() []byte {
-	if packet.Type() == DataPacket {
-		if !packet.HasFlag(FlagMultiAck) {
-			payload := packet.Payload()
-
-			if payload != nil || len(payload) > 0 {
-				payloadSize := len(payload)
-
-				encrypted := make([]byte, payloadSize)
-				packet.Sender().Cipher().XORKeyStream(encrypted, payload)
-
-				packet.SetPayload(encrypted)
-			}
-		}
-
-		if !packet.HasFlag(FlagHasSize) {
-			packet.AddFlag(FlagHasSize)
-		}
-	}
+	//if packet.Type() == DataPacket {
+	//	if !packet.HasFlag(FlagMultiAck) {
+	//		payload := packet.Payload()
+	//
+	//		if payload != nil || len(payload) > 0 {
+	//			payloadSize := len(payload)
+	//
+	//			encrypted := make([]byte, payloadSize)
+	//			packet.Sender().Cipher().XORKeyStream(encrypted, payload)
+	//
+	//			packet.SetPayload(encrypted)
+	//		}
+	//	}
+	//
+	//	if !packet.HasFlag(FlagHasSize) {
+	//		packet.AddFlag(FlagHasSize)
+	//	}
+	//}
 
 	var typeFlags uint16 = packet.Type() | packet.Flags()<<4
 

--- a/rmc.go
+++ b/rmc.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 )
 
+// TODO - We should probably combine RMCRequest and RMCResponse in a single RMCMessage for simpler packet payload setting/reading that supports both request and response payloads
+
 // RMCRequest represets a RMC request
 type RMCRequest struct {
 	protocolID uint8

--- a/sequence_id_manager.go
+++ b/sequence_id_manager.go
@@ -1,0 +1,29 @@
+package nex
+
+// SequenceIDManager implements an API for managing the sequence IDs of different packet streams on a client
+type SequenceIDManager struct {
+	reliableCounter *Counter // TODO - NEX only uses one reliable stream, but Rendezvous supports many. This needs to be a slice!
+	pingCounter     *Counter
+	// TODO - Unreliable packets for Rendezvous
+}
+
+// Next gets the next sequence ID for the packet. Returns 0 for an unsupported packet
+func (s *SequenceIDManager) Next(packet PacketInterface) uint32 {
+	if packet.HasFlag(FlagReliable) {
+		return s.reliableCounter.Increment()
+	}
+
+	if packet.Type() == PingPacket {
+		return s.pingCounter.Increment()
+	}
+
+	return 0
+}
+
+// NewSequenceIDManager returns a new SequenceIDManager
+func NewSequenceIDManager() *SequenceIDManager {
+	return &SequenceIDManager{
+		reliableCounter: NewCounter(0),
+		pingCounter:     NewCounter(0),
+	}
+}

--- a/server.go
+++ b/server.go
@@ -899,7 +899,7 @@ func (server *Server) SendFragment(packet PacketInterface, fragmentID uint8) {
 
 	packet.SetFragmentID(fragmentID)
 	packet.SetPayload(data)
-	packet.SetSequenceID(uint16(client.SequenceIDCounterOut().Increment()))
+	packet.SetSequenceID(uint16(client.SequenceIDOutManager().Next(packet)))
 
 	encodedPacket := packet.Bytes()
 

--- a/server.go
+++ b/server.go
@@ -887,7 +887,7 @@ func (server *Server) SetResendTimeout(resendTimeout time.Duration) {
 	server.resendTimeout = resendTimeout
 }
 
-// SetFragmentSize sets the max number of times a packet can try to resend before assuming the client is dead
+// SetResendMaxIterations sets the max number of times a packet can try to resend before assuming the client is dead
 func (server *Server) SetResendMaxIterations(resendMaxIterations int) {
 	server.resendMaxIterations = resendMaxIterations
 }

--- a/server.go
+++ b/server.go
@@ -55,7 +55,6 @@ type Server struct {
 	natTraversalProtocolVersion *NEXVersion
 	emuSendPacketDropPercent    int
 	emuRecvPacketDropPercent    int
-	port                        int
 }
 
 // Listen starts a NEX server on a given address
@@ -66,9 +65,6 @@ func (server *Server) Listen(address string) {
 	if err != nil {
 		panic(err)
 	}
-
-	// * For debugging the resend manager
-	server.port = udpAddress.Port
 
 	socket, err := net.ListenUDP(protocol, udpAddress)
 	if err != nil {
@@ -890,7 +886,7 @@ func (server *Server) SetResendTimeout(resendTimeout time.Duration) {
 	server.resendTimeout = resendTimeout
 }
 
-// SetResendTimeoutIncrement sets how much to increment the resendTimeout every time a packet is resent to the client 
+// SetResendTimeoutIncrement sets how much to increment the resendTimeout every time a packet is resent to the client
 func (server *Server) SetResendTimeoutIncrement(resendTimeoutIncrement time.Duration) {
 	server.resendTimeoutIncrement = resendTimeoutIncrement
 }

--- a/server.go
+++ b/server.go
@@ -208,6 +208,7 @@ func (server *Server) processPacket(packet PacketInterface) error {
 		server.Emit("Data", packet)
 	case DisconnectPacket:
 		server.Emit("Disconnect", packet)
+		client.StopTimeoutTimer()
 		server.GracefulKick(client)
 	case PingPacket:
 		//server.SendPing(client)

--- a/server.go
+++ b/server.go
@@ -233,7 +233,6 @@ func (server *Server) processPacket(packet PacketInterface) error {
 	case DataPacket:
 		server.Emit("Data", packet)
 	case DisconnectPacket:
-		fmt.Println("Got a DisconnectPacket")
 		server.Emit("Disconnect", packet)
 		server.GracefulKick(client)
 	case PingPacket:

--- a/server.go
+++ b/server.go
@@ -55,6 +55,7 @@ type Server struct {
 	natTraversalProtocolVersion *NEXVersion
 	emuSendPacketDropPercent    int
 	emuRecvPacketDropPercent    int
+	port                        int
 }
 
 // Listen starts a NEX server on a given address
@@ -65,6 +66,9 @@ func (server *Server) Listen(address string) {
 	if err != nil {
 		panic(err)
 	}
+
+	// * For debugging the resend manager
+	server.port = udpAddress.Port
 
 	socket, err := net.ListenUDP(protocol, udpAddress)
 	if err != nil {

--- a/server.go
+++ b/server.go
@@ -235,7 +235,7 @@ func (server *Server) processPacket(packet PacketInterface) error {
 }
 
 func (server *Server) handleAcknowledgement(packet PacketInterface) {
-	if packet.Version() == 0 {
+	if packet.Version() == 0 || (packet.HasFlag(FlagAck) && !packet.HasFlag(FlagMultiAck)) {
 		packet.Sender().outgoingResendManager.Remove(packet.SequenceID())
 	} else {
 		// TODO - Validate the aggregate packet is valid and can be processed

--- a/server.go
+++ b/server.go
@@ -208,7 +208,6 @@ func (server *Server) processPacket(packet PacketInterface) error {
 		server.Emit("Data", packet)
 	case DisconnectPacket:
 		server.Emit("Disconnect", packet)
-		client.StopTimeoutTimer()
 		server.GracefulKick(client)
 	case PingPacket:
 		//server.SendPing(client)
@@ -464,6 +463,7 @@ func (server *Server) GracefulKick(client *Client) {
 
 	server.Emit("Kick", packet)
 	client.SetConnected(false)
+	client.StopTimeoutTimer()
 	discriminator := client.Address().String()
 
 	server.clients.Delete(discriminator)

--- a/server.go
+++ b/server.go
@@ -222,6 +222,7 @@ func (server *Server) processPacket(packet PacketInterface) error {
 	case DataPacket:
 		server.Emit("Data", packet)
 	case DisconnectPacket:
+		fmt.Println("Got a DisconnectPacket")
 		server.Emit("Disconnect", packet)
 		server.GracefulKick(client)
 	case PingPacket:
@@ -1046,7 +1047,7 @@ func NewServer() *Server {
 		clients:                  NewMutexMap[string, *Client](),
 		prudpVersion:             1,
 		fragmentSize:             1300,
-		resendTimeout:            time.Second * 2,
+		resendTimeout:            time.Second,
 		resendMaxIterations:      5,
 		pingTimeout:              5,
 		kerberosKeySize:          32,

--- a/stream_in.go
+++ b/stream_in.go
@@ -20,6 +20,12 @@ func (stream *StreamIn) Remaining() int {
 	return len(stream.Bytes()[stream.ByteOffset():])
 }
 
+// ReadRemaining reads a bool
+func (stream *StreamIn) ReadRemaining() []byte {
+	// TODO - Should we do a bounds check here? Or just allow empty slices?
+	return stream.ReadBytesNext(int64(stream.Remaining()))
+}
+
 // ReadBool reads a bool
 func (stream *StreamIn) ReadBool() (bool, error) {
 	if stream.Remaining() < 1 {

--- a/stream_in.go
+++ b/stream_in.go
@@ -15,9 +15,14 @@ type StreamIn struct {
 	Server *Server
 }
 
+// Remaining reads a bool
+func (stream *StreamIn) Remaining() int {
+	return len(stream.Bytes()[stream.ByteOffset():])
+}
+
 // ReadBool reads a bool
 func (stream *StreamIn) ReadBool() (bool, error) {
-	if len(stream.Bytes()[stream.ByteOffset():]) < 1 {
+	if stream.Remaining() < 1 {
 		return false, errors.New("Not enough data to read bool")
 	}
 
@@ -26,7 +31,7 @@ func (stream *StreamIn) ReadBool() (bool, error) {
 
 // ReadUInt8 reads a uint8
 func (stream *StreamIn) ReadUInt8() (uint8, error) {
-	if len(stream.Bytes()[stream.ByteOffset():]) < 1 {
+	if stream.Remaining() < 1 {
 		return 0, errors.New("Not enough data to read uint8")
 	}
 
@@ -35,7 +40,7 @@ func (stream *StreamIn) ReadUInt8() (uint8, error) {
 
 // ReadInt8 reads a uint8
 func (stream *StreamIn) ReadInt8() (int8, error) {
-	if len(stream.Bytes()[stream.ByteOffset():]) < 1 {
+	if stream.Remaining() < 1 {
 		return 0, errors.New("Not enough data to read int8")
 	}
 
@@ -44,7 +49,7 @@ func (stream *StreamIn) ReadInt8() (int8, error) {
 
 // ReadUInt16LE reads a Little-Endian encoded uint16
 func (stream *StreamIn) ReadUInt16LE() (uint16, error) {
-	if len(stream.Bytes()[stream.ByteOffset():]) < 2 {
+	if stream.Remaining() < 2 {
 		return 0, errors.New("Not enough data to read uint16")
 	}
 
@@ -53,7 +58,7 @@ func (stream *StreamIn) ReadUInt16LE() (uint16, error) {
 
 // ReadUInt16BE reads a Big-Endian encoded uint16
 func (stream *StreamIn) ReadUInt16BE() (uint16, error) {
-	if len(stream.Bytes()[stream.ByteOffset():]) < 2 {
+	if stream.Remaining() < 2 {
 		return 0, errors.New("Not enough data to read uint16")
 	}
 
@@ -62,7 +67,7 @@ func (stream *StreamIn) ReadUInt16BE() (uint16, error) {
 
 // ReadInt16LE reads a Little-Endian encoded int16
 func (stream *StreamIn) ReadInt16LE() (int16, error) {
-	if len(stream.Bytes()[stream.ByteOffset():]) < 2 {
+	if stream.Remaining() < 2 {
 		return 0, errors.New("Not enough data to read int16")
 	}
 
@@ -71,7 +76,7 @@ func (stream *StreamIn) ReadInt16LE() (int16, error) {
 
 // ReadInt16BE reads a Big-Endian encoded int16
 func (stream *StreamIn) ReadInt16BE() (int16, error) {
-	if len(stream.Bytes()[stream.ByteOffset():]) < 2 {
+	if stream.Remaining() < 2 {
 		return 0, errors.New("Not enough data to read int16")
 	}
 
@@ -80,7 +85,7 @@ func (stream *StreamIn) ReadInt16BE() (int16, error) {
 
 // ReadUInt32LE reads a Little-Endian encoded uint32
 func (stream *StreamIn) ReadUInt32LE() (uint32, error) {
-	if len(stream.Bytes()[stream.ByteOffset():]) < 4 {
+	if stream.Remaining() < 4 {
 		return 0, errors.New("Not enough data to read uint32")
 	}
 
@@ -89,7 +94,7 @@ func (stream *StreamIn) ReadUInt32LE() (uint32, error) {
 
 // ReadUInt32BE reads a Big-Endian encoded uint32
 func (stream *StreamIn) ReadUInt32BE() (uint32, error) {
-	if len(stream.Bytes()[stream.ByteOffset():]) < 4 {
+	if stream.Remaining() < 4 {
 		return 0, errors.New("Not enough data to read uint32")
 	}
 
@@ -98,7 +103,7 @@ func (stream *StreamIn) ReadUInt32BE() (uint32, error) {
 
 // ReadInt32LE reads a Little-Endian encoded int32
 func (stream *StreamIn) ReadInt32LE() (int32, error) {
-	if len(stream.Bytes()[stream.ByteOffset():]) < 4 {
+	if stream.Remaining() < 4 {
 		return 0, errors.New("Not enough data to read int32")
 	}
 
@@ -107,7 +112,7 @@ func (stream *StreamIn) ReadInt32LE() (int32, error) {
 
 // ReadInt32BE reads a Big-Endian encoded int32
 func (stream *StreamIn) ReadInt32BE() (int32, error) {
-	if len(stream.Bytes()[stream.ByteOffset():]) < 4 {
+	if stream.Remaining() < 4 {
 		return 0, errors.New("Not enough data to read int32")
 	}
 
@@ -116,7 +121,7 @@ func (stream *StreamIn) ReadInt32BE() (int32, error) {
 
 // ReadUInt64LE reads a Little-Endian encoded uint64
 func (stream *StreamIn) ReadUInt64LE() (uint64, error) {
-	if len(stream.Bytes()[stream.ByteOffset():]) < 8 {
+	if stream.Remaining() < 8 {
 		return 0, errors.New("Not enough data to read uint64")
 	}
 
@@ -125,7 +130,7 @@ func (stream *StreamIn) ReadUInt64LE() (uint64, error) {
 
 // ReadUInt64BE reads a Big-Endian encoded uint64
 func (stream *StreamIn) ReadUInt64BE() (uint64, error) {
-	if len(stream.Bytes()[stream.ByteOffset():]) < 8 {
+	if stream.Remaining() < 8 {
 		return 0, errors.New("Not enough data to read uint64")
 	}
 
@@ -134,7 +139,7 @@ func (stream *StreamIn) ReadUInt64BE() (uint64, error) {
 
 // ReadInt64LE reads a Little-Endian encoded int64
 func (stream *StreamIn) ReadInt64LE() (int64, error) {
-	if len(stream.Bytes()[stream.ByteOffset():]) < 8 {
+	if stream.Remaining() < 8 {
 		return 0, errors.New("Not enough data to read int64")
 	}
 
@@ -143,7 +148,7 @@ func (stream *StreamIn) ReadInt64LE() (int64, error) {
 
 // ReadInt64BE reads a Big-Endian encoded int64
 func (stream *StreamIn) ReadInt64BE() (int64, error) {
-	if len(stream.Bytes()[stream.ByteOffset():]) < 8 {
+	if stream.Remaining() < 8 {
 		return 0, errors.New("Not enough data to read int64")
 	}
 
@@ -152,7 +157,7 @@ func (stream *StreamIn) ReadInt64BE() (int64, error) {
 
 // ReadFloat32LE reads a Little-Endian encoded float32
 func (stream *StreamIn) ReadFloat32LE() (float32, error) {
-	if len(stream.Bytes()[stream.ByteOffset():]) < 4 {
+	if stream.Remaining() < 4 {
 		return 0, errors.New("Not enough data to read float32")
 	}
 
@@ -161,7 +166,7 @@ func (stream *StreamIn) ReadFloat32LE() (float32, error) {
 
 // ReadFloat32BE reads a Big-Endian encoded float32
 func (stream *StreamIn) ReadFloat32BE() (float32, error) {
-	if len(stream.Bytes()[stream.ByteOffset():]) < 4 {
+	if stream.Remaining() < 4 {
 		return 0, errors.New("Not enough data to read float32")
 	}
 
@@ -170,7 +175,7 @@ func (stream *StreamIn) ReadFloat32BE() (float32, error) {
 
 // ReadFloat64LE reads a Little-Endian encoded float64
 func (stream *StreamIn) ReadFloat64LE() (float64, error) {
-	if len(stream.Bytes()[stream.ByteOffset():]) < 8 {
+	if stream.Remaining() < 8 {
 		return 0, errors.New("Not enough data to read float64")
 	}
 
@@ -179,7 +184,7 @@ func (stream *StreamIn) ReadFloat64LE() (float64, error) {
 
 // ReadFloat64BE reads a Big-Endian encoded float64
 func (stream *StreamIn) ReadFloat64BE() (float64, error) {
-	if len(stream.Bytes()[stream.ByteOffset():]) < 8 {
+	if stream.Remaining() < 8 {
 		return 0, errors.New("Not enough data to read float64")
 	}
 
@@ -193,7 +198,7 @@ func (stream *StreamIn) ReadString() (string, error) {
 		return "", fmt.Errorf("Failed to read NEX string length. %s", err.Error())
 	}
 
-	if len(stream.Bytes()[stream.ByteOffset():]) < int(length) {
+	if stream.Remaining() < int(length) {
 		return "", errors.New("NEX string length longer than data size")
 	}
 
@@ -210,7 +215,7 @@ func (stream *StreamIn) ReadBuffer() ([]byte, error) {
 		return []byte{}, fmt.Errorf("Failed to read NEX buffer length. %s", err.Error())
 	}
 
-	if len(stream.Bytes()[stream.ByteOffset():]) < int(length) {
+	if stream.Remaining() < int(length) {
 		return []byte{}, errors.New("NEX buffer length longer than data size")
 	}
 
@@ -226,7 +231,7 @@ func (stream *StreamIn) ReadQBuffer() ([]byte, error) {
 		return []byte{}, fmt.Errorf("Failed to read NEX qBuffer length. %s", err.Error())
 	}
 
-	if len(stream.Bytes()[stream.ByteOffset():]) < int(length) {
+	if stream.Remaining() < int(length) {
 		return []byte{}, errors.New("NEX qBuffer length longer than data size")
 	}
 
@@ -257,7 +262,7 @@ func (stream *StreamIn) ReadStructure(structure StructureInterface) (StructureIn
 			return nil, fmt.Errorf("Failed to read NEX Structure content length. %s", err.Error())
 		}
 
-		if len(stream.Bytes()[stream.ByteOffset():]) < int(structureLength) {
+		if stream.Remaining() < int(structureLength) {
 			return nil, errors.New("NEX Structure content length longer than data size")
 		}
 
@@ -373,7 +378,7 @@ func (stream *StreamIn) ReadListUInt8() ([]uint8, error) {
 		return nil, fmt.Errorf("Failed to read List<uint8> length. %s", err.Error())
 	}
 
-	if len(stream.Bytes()[stream.ByteOffset():]) < int(length) {
+	if stream.Remaining() < int(length) {
 		return nil, errors.New("NEX List<uint8> length longer than data size")
 	}
 
@@ -398,7 +403,7 @@ func (stream *StreamIn) ReadListInt8() ([]int8, error) {
 		return nil, fmt.Errorf("Failed to read List<int8> length. %s", err.Error())
 	}
 
-	if len(stream.Bytes()[stream.ByteOffset():]) < int(length) {
+	if stream.Remaining() < int(length) {
 		return nil, errors.New("NEX List<int8> length longer than data size")
 	}
 
@@ -423,7 +428,7 @@ func (stream *StreamIn) ReadListUInt16LE() ([]uint16, error) {
 		return nil, fmt.Errorf("Failed to read List<uint16> length. %s", err.Error())
 	}
 
-	if len(stream.Bytes()[stream.ByteOffset():]) < int(length*2) {
+	if stream.Remaining() < int(length*2) {
 		return nil, errors.New("NEX List<uint16> length longer than data size")
 	}
 
@@ -448,7 +453,7 @@ func (stream *StreamIn) ReadListUInt16BE() ([]uint16, error) {
 		return nil, fmt.Errorf("Failed to read List<uint16> length. %s", err.Error())
 	}
 
-	if len(stream.Bytes()[stream.ByteOffset():]) < int(length*2) {
+	if stream.Remaining() < int(length*2) {
 		return nil, errors.New("NEX List<uint16> length longer than data size")
 	}
 
@@ -473,7 +478,7 @@ func (stream *StreamIn) ReadListInt16LE() ([]int16, error) {
 		return nil, fmt.Errorf("Failed to read List<int16> length. %s", err.Error())
 	}
 
-	if len(stream.Bytes()[stream.ByteOffset():]) < int(length*2) {
+	if stream.Remaining() < int(length*2) {
 		return nil, errors.New("NEX List<int16> length longer than data size")
 	}
 
@@ -498,7 +503,7 @@ func (stream *StreamIn) ReadListInt16BE() ([]int16, error) {
 		return nil, fmt.Errorf("Failed to read List<int16> length. %s", err.Error())
 	}
 
-	if len(stream.Bytes()[stream.ByteOffset():]) < int(length*2) {
+	if stream.Remaining() < int(length*2) {
 		return nil, errors.New("NEX List<int16> length longer than data size")
 	}
 
@@ -523,7 +528,7 @@ func (stream *StreamIn) ReadListUInt32LE() ([]uint32, error) {
 		return nil, fmt.Errorf("Failed to read List<uint32> length. %s", err.Error())
 	}
 
-	if len(stream.Bytes()[stream.ByteOffset():]) < int(length*4) {
+	if stream.Remaining() < int(length*4) {
 		return nil, errors.New("NEX List<uint32> length longer than data size")
 	}
 
@@ -548,7 +553,7 @@ func (stream *StreamIn) ReadListUInt32BE() ([]uint32, error) {
 		return nil, fmt.Errorf("Failed to read List<uint32> length. %s", err.Error())
 	}
 
-	if len(stream.Bytes()[stream.ByteOffset():]) < int(length*4) {
+	if stream.Remaining() < int(length*4) {
 		return nil, errors.New("NEX List<uint32> length longer than data size")
 	}
 
@@ -573,7 +578,7 @@ func (stream *StreamIn) ReadListInt32LE() ([]int32, error) {
 		return nil, fmt.Errorf("Failed to read List<int32> length. %s", err.Error())
 	}
 
-	if len(stream.Bytes()[stream.ByteOffset():]) < int(length*4) {
+	if stream.Remaining() < int(length*4) {
 		return nil, errors.New("NEX List<int32> length longer than data size")
 	}
 
@@ -598,7 +603,7 @@ func (stream *StreamIn) ReadListInt32BE() ([]int32, error) {
 		return nil, fmt.Errorf("Failed to read List<int32> length. %s", err.Error())
 	}
 
-	if len(stream.Bytes()[stream.ByteOffset():]) < int(length*4) {
+	if stream.Remaining() < int(length*4) {
 		return nil, errors.New("NEX List<int32> length longer than data size")
 	}
 
@@ -623,7 +628,7 @@ func (stream *StreamIn) ReadListUInt64LE() ([]uint64, error) {
 		return nil, fmt.Errorf("Failed to read List<uint64> length. %s", err.Error())
 	}
 
-	if len(stream.Bytes()[stream.ByteOffset():]) < int(length*8) {
+	if stream.Remaining() < int(length*8) {
 		return nil, errors.New("NEX List<uint64> length longer than data size")
 	}
 
@@ -648,7 +653,7 @@ func (stream *StreamIn) ReadListUInt64BE() ([]uint64, error) {
 		return nil, fmt.Errorf("Failed to read List<uint64> length. %s", err.Error())
 	}
 
-	if len(stream.Bytes()[stream.ByteOffset():]) < int(length*8) {
+	if stream.Remaining() < int(length*8) {
 		return nil, errors.New("NEX List<uint64> length longer than data size")
 	}
 
@@ -673,7 +678,7 @@ func (stream *StreamIn) ReadListInt64LE() ([]int64, error) {
 		return nil, fmt.Errorf("Failed to read List<int64> length. %s", err.Error())
 	}
 
-	if len(stream.Bytes()[stream.ByteOffset():]) < int(length*8) {
+	if stream.Remaining() < int(length*8) {
 		return nil, errors.New("NEX List<int64> length longer than data size")
 	}
 
@@ -698,7 +703,7 @@ func (stream *StreamIn) ReadListInt64BE() ([]int64, error) {
 		return nil, fmt.Errorf("Failed to read List<int64> length. %s", err.Error())
 	}
 
-	if len(stream.Bytes()[stream.ByteOffset():]) < int(length*8) {
+	if stream.Remaining() < int(length*8) {
 		return nil, errors.New("NEX List<int64> length longer than data size")
 	}
 
@@ -723,7 +728,7 @@ func (stream *StreamIn) ReadListFloat32LE() ([]float32, error) {
 		return nil, fmt.Errorf("Failed to read List<float32> length. %s", err.Error())
 	}
 
-	if len(stream.Bytes()[stream.ByteOffset():]) < int(length*4) {
+	if stream.Remaining() < int(length*4) {
 		return nil, errors.New("NEX List<float32> length longer than data size")
 	}
 
@@ -748,7 +753,7 @@ func (stream *StreamIn) ReadListFloat32BE() ([]float32, error) {
 		return nil, fmt.Errorf("Failed to read List<float32> length. %s", err.Error())
 	}
 
-	if len(stream.Bytes()[stream.ByteOffset():]) < int(length*4) {
+	if stream.Remaining() < int(length*4) {
 		return nil, errors.New("NEX List<float32> length longer than data size")
 	}
 
@@ -773,7 +778,7 @@ func (stream *StreamIn) ReadListFloat64LE() ([]float64, error) {
 		return nil, fmt.Errorf("Failed to read List<float64> length. %s", err.Error())
 	}
 
-	if len(stream.Bytes()[stream.ByteOffset():]) < int(length*4) {
+	if stream.Remaining() < int(length*4) {
 		return nil, errors.New("NEX List<float64> length longer than data size")
 	}
 
@@ -798,7 +803,7 @@ func (stream *StreamIn) ReadListFloat64BE() ([]float64, error) {
 		return nil, fmt.Errorf("Failed to read List<float64> length. %s", err.Error())
 	}
 
-	if len(stream.Bytes()[stream.ByteOffset():]) < int(length*4) {
+	if stream.Remaining() < int(length*4) {
 		return nil, errors.New("NEX List<float64> length longer than data size")
 	}
 

--- a/stream_in.go
+++ b/stream_in.go
@@ -15,12 +15,12 @@ type StreamIn struct {
 	Server *Server
 }
 
-// Remaining reads a bool
+// Remaining returns the amount of data left to be read in the buffer
 func (stream *StreamIn) Remaining() int {
 	return len(stream.Bytes()[stream.ByteOffset():])
 }
 
-// ReadRemaining reads a bool
+// ReadRemaining reads all the data left to be read in the buffer
 func (stream *StreamIn) ReadRemaining() []byte {
 	// TODO - Should we do a bounds check here? Or just allow empty slices?
 	return stream.ReadBytesNext(int64(stream.Remaining()))


### PR DESCRIPTION
## ~~DRAFT UNTIL MORE WIDELY TESTED. CONTAINS *LOTS* OF EXPERIMENTAL CHANGES~~

## All hands on deck for this one, this branch is part of this repo so anyone with `maintain` permissions can push directly here to add changes

PR aims to add the following

- [x] Better concurrent map access for Go routines by using mutex locks
- [x] More reliable packet handling

### Concurrent map access

Better concurrent map access for Go routines is implemented with the new `MutexMap` struct. This is a generic struct which takes in 2 types, the first being the maps key type and second being the maps value type. `MutexMap` provides a simple API for reads and writes through `Get` and `Set` methods and handles mutex locks on it's own

*`MutexMap` embeds `sync.RWMutex` directly*. This is done because the Go `range` keyword has no interface we can use to make custom types compatible with it. Embedding `sync.RWMutex` directly allows us to manually lock and unlock the mutex to perform loops. This is ugly code, I hope it can be made better through the `MutexMap` API before this is merged but it is not a priority

### Reliable packet handling

More reliable packet handling has 2 requirements

- [x] Deferred packet handling, for missing packets (both dropped during transmission and packets received out of order)
- [x] Server->client packet retransmission

### Deferred packet handling

Deferred packet handling is being implemented using a new `PacketManager` struct

This is _**HIGHLY EXPERIMENTAL**_. It has worked in all tests I have ran locally, but I never had these issues locally to begin with. Needs to be tested in an environment where packets do seem to be dropped or received out of order, such as the CTGP-7 server

This struct provides a simple API to push packets into a pool using `Push`. The `Next` method loops over this pool to find the next expected packet and returns it if found. The manager tracks it's own sequence ID counter and removes "popped" packets from the pool in `Next` to keep memory usage under control. If the next expected packet is not in the pool, `nil` is returned

### Packet retransmission

Server->client packet retransmission is not being implemented _**AT ALL**_ right now. ~~Ideally this would be added to this branch before merging, but I am willing to put this off if it's not an issue just to get the other changes out faster. This could likely be implemented by using the above mentioned `PacketManager` but extending the API to also track packets which need to be acknowledged still. Creating a loop similar to the [timeout timer found on Client](https://github.com/PretendoNetwork/nex-go/blob/acd5855c0d57898ead4c06b7fb95716483c7d242/client.go#L225-L234) and resending the packets that have not been acknowledged~~

This is now part of this PR, implemented using the new `PacketResendManager`