### PR TITLE
Add emulated packet drop option

### DIFF
--- a/server.go
+++ b/server.go
@@ -891,6 +891,7 @@ func (server *Server) SendRaw(conn *net.UDPAddr, data []byte) {
 		// Emulate packet drop for debugging
 		return
 	}
+
 	_, err := server.Socket().WriteToUDP(data, conn)
 	if err != nil {
 		// TODO - Should this return the error too?

--- a/server.go
+++ b/server.go
@@ -11,6 +11,7 @@ package nex
 import (
 	"crypto/rand"
 	"fmt"
+	mrand "math/rand"
 	"net"
 	"net/http"
 	"runtime"
@@ -50,6 +51,8 @@ type Server struct {
 	messagingProtocolVersion    *NEXVersion
 	utilityProtocolVersion      *NEXVersion
 	natTraversalProtocolVersion *NEXVersion
+	emuSendPacketDropPercent    int
+	emuRecvPacketDropPercent    int
 }
 
 // Listen starts a NEX server on a given address
@@ -101,6 +104,11 @@ func (server *Server) handleSocketMessage() error {
 	length, addr, err := socket.ReadFromUDP(buffer[0:])
 	if err != nil {
 		return err
+	}
+
+	if server.shouldDropPacket(true) {
+		// Emulate packet drop for debugging
+		return nil
 	}
 
 	discriminator := addr.String()
@@ -879,10 +887,31 @@ func (server *Server) SendFragment(packet PacketInterface, fragmentID uint8) {
 
 // SendRaw writes raw packet data to the client socket
 func (server *Server) SendRaw(conn *net.UDPAddr, data []byte) {
+	if server.shouldDropPacket(false) {
+		// Emulate packet drop for debugging
+		return
+	}
 	_, err := server.Socket().WriteToUDP(data, conn)
 	if err != nil {
 		// TODO - Should this return the error too?
 		logger.Error(err.Error())
+	}
+}
+
+func (server *Server) shouldDropPacket(isRecv bool) bool {
+	if isRecv {
+		return server.emuRecvPacketDropPercent != 0 && mrand.Intn(100) < server.emuRecvPacketDropPercent
+	} else {
+		return server.emuSendPacketDropPercent != 0 && mrand.Intn(100) < server.emuSendPacketDropPercent
+	}
+}
+
+// SetEmulatedPacketDropPercent sets the percentage of emulated sent and received dropped packets, set to 0 to disable.
+func (server *Server) SetEmulatedPacketDropPercent(forRecv bool, percent int) {
+	if forRecv {
+		server.emuRecvPacketDropPercent = percent
+	} else {
+		server.emuSendPacketDropPercent = percent
 	}
 }
 
@@ -903,6 +932,8 @@ func NewServer() *Server {
 		kerberosKeySize:       32,
 		kerberosKeyDerivation: 0,
 		connectionIDCounter:   NewCounter(10),
+		emuSendPacketDropPercent: 0,
+		emuRecvPacketDropPercent: 0,
 	}
 
 	server.SetDefaultNEXVersion(NewNEXVersion(0, 0, 0))

--- a/server.go
+++ b/server.go
@@ -906,7 +906,7 @@ func (server *Server) shouldDropPacket(isRecv bool) bool {
 	}
 }
 
-// SetEmulatedPacketDropPercent sets the percentage of emulated sent and received dropped packets, set to 0 to disable.
+// SetEmulatedPacketDropPercent sets the percentage of emulated sent and received dropped packets
 func (server *Server) SetEmulatedPacketDropPercent(forRecv bool, percent int) {
 	if forRecv {
 		server.emuRecvPacketDropPercent = percent


### PR DESCRIPTION
Adds the possibility to emulate packet drops on the server side, to test proper reliable packet handling.