### PR TITLE
Fix deadlock in PacketResendManager

### DIFF
--- a/mutex_map.go
+++ b/mutex_map.go
@@ -42,8 +42,9 @@ func (m *MutexMap[K, V]) Size() int {
 	return len(m.real)
 }
 
-// Each runs a function for every item in the map
-// the function takes in the items key and value
+// Each runs a callback function for every item in the map
+// the callback function takes in the items key and value
+// the map should not be modified inside the callback function
 func (m *MutexMap[K, V]) Each(callback func(key K, value V)) {
 	m.RLock()
 	defer m.RUnlock()

--- a/mutex_map.go
+++ b/mutex_map.go
@@ -10,8 +10,8 @@ type MutexMap[K comparable, V any] struct {
 
 // Set sets a key to a given value
 func (m *MutexMap[K, V]) Set(key K, value V) {
-	m.Lock()
-	defer m.Unlock()
+	m.RLock()
+	defer m.RUnlock()
 
 	m.real[key] = value
 }
@@ -28,8 +28,8 @@ func (m *MutexMap[K, V]) Get(key K) (V, bool) {
 
 // Delete removes a key from the internal map
 func (m *MutexMap[K, V]) Delete(key K) {
-	m.Lock()
-	defer m.Unlock()
+	m.RLock()
+	defer m.RUnlock()
 
 	delete(m.real, key)
 }

--- a/mutex_map.go
+++ b/mutex_map.go
@@ -10,8 +10,8 @@ type MutexMap[K comparable, V any] struct {
 
 // Set sets a key to a given value
 func (m *MutexMap[K, V]) Set(key K, value V) {
-	m.RLock()
-	defer m.RUnlock()
+	m.Lock()
+	defer m.Unlock()
 
 	m.real[key] = value
 }
@@ -28,8 +28,8 @@ func (m *MutexMap[K, V]) Get(key K) (V, bool) {
 
 // Delete removes a key from the internal map
 func (m *MutexMap[K, V]) Delete(key K) {
-	m.RLock()
-	defer m.RUnlock()
+	m.Lock()
+	defer m.Unlock()
 
 	delete(m.real, key)
 }
@@ -50,6 +50,18 @@ func (m *MutexMap[K, V]) Each(callback func(key K, value V)) {
 
 	for key, value := range m.real {
 		callback(key, value)
+	}
+}
+
+// Clear clears the map and runs a function for every item removed
+// the function takes in the items key and value
+func (m *MutexMap[K, V]) Clear(callback func (key K, value V)) {
+	m.Lock()
+	defer m.Unlock()
+
+	for key, value := range m.real {
+		callback(key, value)
+		delete(m.real, key)
 	}
 }
 

--- a/mutex_map.go
+++ b/mutex_map.go
@@ -43,8 +43,7 @@ func (m *MutexMap[K, V]) Size() int {
 }
 
 // Each runs a callback function for every item in the map
-// the callback function takes in the items key and value
-// the map should not be modified inside the callback function
+// The map should not be modified inside the callback function
 func (m *MutexMap[K, V]) Each(callback func(key K, value V)) {
 	m.RLock()
 	defer m.RUnlock()

--- a/mutex_map.go
+++ b/mutex_map.go
@@ -53,14 +53,16 @@ func (m *MutexMap[K, V]) Each(callback func(key K, value V)) {
 	}
 }
 
-// Clear clears the map and runs a function for every item removed
-// the function takes in the items key and value
-func (m *MutexMap[K, V]) Clear(callback func (key K, value V)) {
+// Clear removes all items from the `real` map
+// Accepts an optional callback function ran for every item before it is deleted
+func (m *MutexMap[K, V]) Clear(callback func(key K, value V)) {
 	m.Lock()
 	defer m.Unlock()
 
 	for key, value := range m.real {
-		callback(key, value)
+		if callback != nil {
+			callback(key, value)
+		}
 		delete(m.real, key)
 	}
 }

--- a/packet_resend_manager.go
+++ b/packet_resend_manager.go
@@ -84,8 +84,8 @@ func (p *PacketResendManager) Remove(sequenceID uint16) {
 
 // Clear removes all packets from pool and stops their timers
 func (p *PacketResendManager) Clear() {
-	p.pending.Each(func(key uint16, value *PendingPacket) {
-		p.Remove(value.packet.SequenceID())
+	p.pending.Clear(func(key uint16, value *PendingPacket) {
+		value.StopTimeoutTimer()
 	})
 }
 


### PR DESCRIPTION
Without this change, `PacketResendManager.Clear()` was deadlocking.