### PR TITLE
Add timeout increment to packet resend manager

### DIFF
--- a/client.go
+++ b/client.go
@@ -48,7 +48,7 @@ func (client *Client) Reset() error {
 		client.outgoingResendManager.Clear()
 	}
 
-	client.outgoingResendManager = NewPacketResendManager(server.resendTimeout, server.resendMaxIterations)
+	client.outgoingResendManager = NewPacketResendManager(server.resendTimeout, server.resendTimeoutIncrement, server.resendMaxIterations)
 
 	client.UpdateAccessKey(server.AccessKey())
 	err := client.UpdateRC4Key([]byte("CD&ML"))

--- a/packet_resend_manager.go
+++ b/packet_resend_manager.go
@@ -37,8 +37,9 @@ func (p *PendingPacket) BeginTimeoutTimer() {
 				} else {
 					if p.timeoutInc != 0 {
 						p.timeout += p.timeoutInc
-						p.ticker = time.NewTicker(p.timeout)
+						p.ticker.Reset(p.timeout)
 					}
+
 					// * Resend the packet
 					server.SendRaw(client.Address(), p.packet.Bytes())
 				}
@@ -59,7 +60,7 @@ func (p *PendingPacket) StopTimeoutTimer() {
 // NewPendingPacket returns a new PendingPacket
 func NewPendingPacket(packet PacketInterface, timeoutTime time.Duration, timeoutIncrement time.Duration, maxIterations int) *PendingPacket {
 	p := &PendingPacket{
-		ticking: 	   true,
+		ticking:       true,
 		ticker:        time.NewTicker(timeoutTime),
 		quit:          make(chan struct{}),
 		packet:        packet,

--- a/packet_resend_manager.go
+++ b/packet_resend_manager.go
@@ -12,6 +12,8 @@ type PendingPacket struct {
 	quit          chan struct{}
 	packet        PacketInterface
 	iterations    *Counter
+	timeout       time.Duration
+	timeoutInc    time.Duration
 	maxIterations int
 }
 
@@ -33,6 +35,10 @@ func (p *PendingPacket) BeginTimeoutTimer() {
 					p.StopTimeoutTimer()
 					return
 				} else {
+					if p.timeoutInc != 0 {
+						p.timeout += p.timeoutInc
+						p.ticker = time.NewTicker(p.timeout)
+					}
 					// * Resend the packet
 					server.SendRaw(client.Address(), p.packet.Bytes())
 				}
@@ -51,13 +57,15 @@ func (p *PendingPacket) StopTimeoutTimer() {
 }
 
 // NewPendingPacket returns a new PendingPacket
-func NewPendingPacket(packet PacketInterface, timeoutTime time.Duration, maxIterations int) *PendingPacket {
+func NewPendingPacket(packet PacketInterface, timeoutTime time.Duration, timeoutIncrement time.Duration, maxIterations int) *PendingPacket {
 	p := &PendingPacket{
 		ticking: 	   true,
 		ticker:        time.NewTicker(timeoutTime),
 		quit:          make(chan struct{}),
 		packet:        packet,
 		iterations:    NewCounter(0),
+		timeout:       timeoutTime,
+		timeoutInc:    timeoutIncrement,
 		maxIterations: maxIterations,
 	}
 
@@ -68,12 +76,13 @@ func NewPendingPacket(packet PacketInterface, timeoutTime time.Duration, maxIter
 type PacketResendManager struct {
 	pending       *MutexMap[uint16, *PendingPacket]
 	timeoutTime   time.Duration
+	timeoutInc    time.Duration
 	maxIterations int
 }
 
 // Add creates a PendingPacket, adds it to the pool, and begins it's timeout timer
 func (p *PacketResendManager) Add(packet PacketInterface) {
-	cached := NewPendingPacket(packet, p.timeoutTime, p.maxIterations)
+	cached := NewPendingPacket(packet, p.timeoutTime, p.timeoutInc, p.maxIterations)
 	p.pending.Set(packet.SequenceID(), cached)
 
 	cached.BeginTimeoutTimer()
@@ -95,10 +104,11 @@ func (p *PacketResendManager) Clear() {
 }
 
 // NewPacketResendManager returns a new PacketResendManager
-func NewPacketResendManager(timeoutTime time.Duration, maxIterations int) *PacketResendManager {
+func NewPacketResendManager(timeoutTime time.Duration, timeoutIncrement time.Duration, maxIterations int) *PacketResendManager {
 	return &PacketResendManager{
 		pending:       NewMutexMap[uint16, *PendingPacket](),
 		timeoutTime:   timeoutTime,
+		timeoutInc:    timeoutIncrement,
 		maxIterations: maxIterations,
 	}
 }

--- a/server.go
+++ b/server.go
@@ -37,6 +37,7 @@ type Server struct {
 	supportedFunctions          int
 	fragmentSize                int16
 	resendTimeout               time.Duration
+	resendTimeoutIncrement		time.Duration
 	resendMaxIterations         int
 	pingTimeout                 int
 	kerberosPassword            string
@@ -890,6 +891,11 @@ func (server *Server) SetResendTimeout(resendTimeout time.Duration) {
 	server.resendTimeout = resendTimeout
 }
 
+// SetResendTimeoutIncrement sets how much to increment the resendTimeout every time a packet is resent to the client 
+func (server *Server) SetResendTimeoutIncrement(resendTimeoutIncrement time.Duration) {
+	server.resendTimeoutIncrement = resendTimeoutIncrement
+}
+
 // SetResendMaxIterations sets the max number of times a packet can try to resend before assuming the client is dead
 func (server *Server) SetResendMaxIterations(resendMaxIterations int) {
 	server.resendMaxIterations = resendMaxIterations
@@ -1058,6 +1064,7 @@ func NewServer() *Server {
 		prudpVersion:             1,
 		fragmentSize:             1300,
 		resendTimeout:            time.Second,
+		resendTimeoutIncrement:   0,
 		resendMaxIterations:      5,
 		pingTimeout:              5,
 		kerberosKeySize:          32,

--- a/server.go
+++ b/server.go
@@ -37,7 +37,7 @@ type Server struct {
 	supportedFunctions          int
 	fragmentSize                int16
 	resendTimeout               time.Duration
-	resendTimeoutIncrement		time.Duration
+	resendTimeoutIncrement      time.Duration
 	resendMaxIterations         int
 	pingTimeout                 int
 	kerberosPassword            string


### PR DESCRIPTION
Adds `server.SetResendTimeoutIncrement`, which allow incrementing the resend timeout an specific amount on every resend attempt.

This change allows replicating what Mario Kart 7 nex does. The first resent packet is sent after a timeout of 0.5 seconds, and every successive packet has its timeout incremented by 0.5 seconds. (So, packet - wait 0.5s - packet - wait 1.0s - packet - wait 1.5s -packet...). This is done 15 times, so the total timeout time is 60 seconds.