### PR TITLE
Implement and use deleteConnectionByID

### DIFF
--- a/mutex_map.go
+++ b/mutex_map.go
@@ -43,6 +43,23 @@ func (m *MutexMap[K, V]) Delete(key K) {
 	delete(m.real, key)
 }
 
+// DeleteIf deletes every element if the callback returns true.
+// Returns the amount of elements deleted.
+func (m *MutexMap[K, V]) DeleteIf(callback func(key K, value V) bool) int {
+	m.Lock()
+	defer m.Unlock()
+	
+	amout := 0
+	for key, value := range m.real {
+		if callback(key, value) {
+			delete(m.real, key)
+			amout++
+		}
+	}
+
+	return amout
+}
+
 // RunAndDelete runs a callback and removes the key afterwards
 func (m *MutexMap[K, V]) RunAndDelete(key K, callback func(key K, value V)) {
 	m.Lock()

--- a/mutex_map.go
+++ b/mutex_map.go
@@ -43,15 +43,15 @@ func (m *MutexMap[K, V]) Delete(key K) {
 	delete(m.real, key)
 }
 
-// DeleteIf deletes every element if the callback returns true.
+// DeleteIf deletes every element if the predicate returns true.
 // Returns the amount of elements deleted.
-func (m *MutexMap[K, V]) DeleteIf(callback func(key K, value V) bool) int {
+func (m *MutexMap[K, V]) DeleteIf(predicate func(key K, value V) bool) int {
 	m.Lock()
 	defer m.Unlock()
 
 	amount := 0
 	for key, value := range m.real {
-		if callback(key, value) {
+		if predicate(key, value) {
 			delete(m.real, key)
 			amount++
 		}

--- a/mutex_map.go
+++ b/mutex_map.go
@@ -48,16 +48,16 @@ func (m *MutexMap[K, V]) Delete(key K) {
 func (m *MutexMap[K, V]) DeleteIf(callback func(key K, value V) bool) int {
 	m.Lock()
 	defer m.Unlock()
-	
-	amout := 0
+
+	amount := 0
 	for key, value := range m.real {
 		if callback(key, value) {
 			delete(m.real, key)
-			amout++
+			amount++
 		}
 	}
 
-	return amout
+	return amount
 }
 
 // RunAndDelete runs a callback and removes the key afterwards

--- a/prudp_connection.go
+++ b/prudp_connection.go
@@ -2,7 +2,6 @@ package nex
 
 import (
 	"crypto/md5"
-	"fmt"
 	"net"
 	"time"
 
@@ -195,9 +194,7 @@ func (pc *PRUDPConnection) startHeartbeat() {
 		pc.pingKickTimer = time.AfterFunc(maxSilenceTime, func() {
 			pc.cleanup() // * "removed" event is dispatched here
 
-			discriminator := fmt.Sprintf("%s-%d-%d", pc.Socket.Address.String(), pc.StreamType, pc.StreamID)
-
-			endpoint.Connections.Delete(discriminator)
+			endpoint.deleteConnectionByID(pc.ID)
 		})
 	})
 }

--- a/prudp_endpoint.go
+++ b/prudp_endpoint.go
@@ -100,6 +100,13 @@ func (pep *PRUDPEndPoint) EmitError(err *Error) {
 	}
 }
 
+// deleteConnectionByID deletes the connection with the specified ID
+func (pep *PRUDPEndPoint) deleteConnectionByID(cid uint32) {
+	pep.Connections.DeleteIf(func(key string, value *PRUDPConnection) bool {
+		return value.ID == cid
+	})
+}
+
 func (pep *PRUDPEndPoint) processPacket(packet PRUDPPacketInterface, socket *SocketConnection) {
 	streamType := packet.SourceVirtualPortStreamType()
 	streamID := packet.SourceVirtualPortStreamID()

--- a/resend_scheduler.go
+++ b/resend_scheduler.go
@@ -1,7 +1,6 @@
 package nex
 
 import (
-	"fmt"
 	"time"
 )
 
@@ -105,11 +104,7 @@ func (rs *ResendScheduler) resendPacket(pendingPacket *PendingPacket) {
 		rs.packets.Delete(packet.SequenceID())
 		connection.cleanup() // * "removed" event is dispatched here
 
-		streamType := packet.SourceVirtualPortStreamType()
-		streamID := packet.SourceVirtualPortStreamID()
-		discriminator := fmt.Sprintf("%s-%d-%d", packet.Sender().Address().String(), streamType, streamID)
-
-		connection.endpoint.Connections.Delete(discriminator)
+		connection.endpoint.deleteConnectionByID(connection.ID)
 
 		return
 	}


### PR DESCRIPTION
I observed some cases where timed out connections would stay in the endpoint connections `MutexMap`, but the disconnect callbacks were being called. This can be explained by the incorrect calculation of the `discriminator` value used as a key in the delete method, for some reason. To fix that I have implemented a `deleteConnectionByID` method which is easier to use in some situations.