### PR TITLE
Revert connection state checks

### DIFF
--- a/prudp_endpoint.go
+++ b/prudp_endpoint.go
@@ -142,11 +142,6 @@ func (pep *PRUDPEndPoint) processPacket(packet PRUDPPacketInterface, socket *Soc
 
 func (pep *PRUDPEndPoint) handleAcknowledgment(packet PRUDPPacketInterface) {
 	connection := packet.Sender().(*PRUDPConnection)
-	if connection.ConnectionState != StateConnected {
-		// TODO - Log this?
-		// * Connection is in a bad state, drop the packet and let it die
-		return
-	}
 
 	if packet.HasFlag(constants.PacketFlagMultiAck) {
 		pep.handleMultiAcknowledgment(packet)
@@ -208,12 +203,6 @@ func (pep *PRUDPEndPoint) handleMultiAcknowledgment(packet PRUDPPacketInterface)
 func (pep *PRUDPEndPoint) handleSyn(packet PRUDPPacketInterface) {
 	connection := packet.Sender().(*PRUDPConnection)
 
-	if connection.ConnectionState != StateNotConnected {
-		// TODO - Log this?
-		// * Connection is in a bad state, drop the packet and let it die
-		return
-	}
-
 	var ack PRUDPPacketInterface
 
 	if packet.Version() == 2 {
@@ -258,12 +247,6 @@ func (pep *PRUDPEndPoint) handleSyn(packet PRUDPPacketInterface) {
 
 func (pep *PRUDPEndPoint) handleConnect(packet PRUDPPacketInterface) {
 	connection := packet.Sender().(*PRUDPConnection)
-
-	if connection.ConnectionState != StateConnecting {
-		// TODO - Log this?
-		// * Connection is in a bad state, drop the packet and let it die
-		return
-	}
 
 	var ack PRUDPPacketInterface
 
@@ -383,14 +366,6 @@ func (pep *PRUDPEndPoint) handleConnect(packet PRUDPPacketInterface) {
 }
 
 func (pep *PRUDPEndPoint) handleData(packet PRUDPPacketInterface) {
-	connection := packet.Sender().(*PRUDPConnection)
-
-	if connection.ConnectionState != StateConnected {
-		// TODO - Log this?
-		// * Connection is in a bad state, drop the packet and let it die
-		return
-	}
-
 	if packet.HasFlag(constants.PacketFlagReliable) {
 		pep.handleReliable(packet)
 	} else {


### PR DESCRIPTION
Draft for now since there are still unsolved issues.

Reverts the `ConnectionState` checks on the server. This seems to only be validated on the client. This was a flawed check and introduced some connection issues. The server would update the the clients connection state at times when it could not verify that the action happened successfully. Namely in the `SYN` and `CONNECT` packet handlers. It's possible for the `SYN ACK` or `CONNECT ACK` to get dropped and never reach the client, resulting in the client trying to resend those packets. However the server has already updated the clients connection state to go to the next step, and would drop any incoming packets resent from the previous state, dropping an otherwise good connection.

This issue occured several times for me during local testing, and last night @ashquarky confirmed that removing these checks seemed to clear up some connection issues for them and many others when done in prod.

This is also not accurate emulation. As seen by this screenshot from the Nintendo Network Friends server, the server seems to always respond to packets regardless of the clients connection state. Which seems to imply it doesn't track it at all. In this case the `SYN` packet was resent and resulted in 2 `SYN ACK` packets from the server.

![Screenshot_from_2024-04-23_15-35-42](https://github.com/PretendoNetwork/nex-go/assets/27011796/01f33ab3-01e6-4fa5-90a5-c4bb3eeacaae)

However removing these checks alone has introduced a regression it seems. I have hot-patched these changes onto the live friends server and the logs now show many `RMC Message has unexpected size` errors. I believe this is due to the clients RMC ciphers not being reset correctly, but I'm unsure?

In the `SYN` packet handler the `PRUDPConnection.reset` function is called, which runs `pc.slidingWindows.Clear`. This ***SHOULD*** be removing all the clients RMC ciphers, but clearly something is still going wrong? Due to this regression, this has been marked as a draft for now.