### PR TITLE
feat(list): Add TransformList and NewListTransformed to aid in conversions

### DIFF
--- a/types/list.go
+++ b/types/list.go
@@ -181,3 +181,27 @@ func (l *List[T]) String() string {
 func NewList[T RVType]() *List[T] {
 	return &List[T]{real: make([]T, 0)}
 }
+
+// TransformList applies closure f to each element of the List, returning the result as a slice
+func TransformList[T RVType, R any](l *List[T], f func(T) R) []R {
+	result := make([]R, l.Length())
+
+	for i, v := range l.real {
+		result[i] = f(v)
+	}
+
+	return result
+}
+
+// NewListTransformed applies closure f to each element of a slice, creating a List from the results
+func NewListTransformed[T RVType, R any](l []R, f func(R) T) *List[T] {
+	result := make([]T, len(l))
+
+	for i, v := range l {
+		result[i] = f(v)
+	}
+
+	nexlist := NewList[T]()
+	nexlist.SetFromData(result)
+	return nexlist
+}


### PR DESCRIPTION
Lists of RVTypes can be difficult to feed into other libraries. For example, `List[String]` shows up in DataStore in a few places, whereas the database engine expects a `[]string`.

These two functions allow for more ergonomic conversions between NEX types and their primitives. 
Using `List[String]` as an example, here's converting *to* primitives for the database:

```go
getString := func(p *nextypes.String) string { return p.Value }

db.Query(`INSERT INTO...`,
    pq.Array(nextypes.TransformList(param.Tags, getString)),
)
```

Converting *from* primitives is nicer again, due to the `NewString` function already having the right signature:

```go
var tags []string
db.Query(`SELECT ...`).Scan(pq.Array(&tags))

result.Tags = nextypes.NewListTransformed(tags, nextypes.NewString)
```

Ideally we would [implement Scanner and Valuer](https://husobee.github.io/golang/database/2015/06/12/scanner-valuer.html) so the database engine can work on our types directly (no conversions), but that would require adding `database/sql/driver` as a dependency which may or may not be acceptable. Let me know if I can do that though.