### PR TITLE
Add locking to SlidingWindow

### DIFF
--- a/prudp_endpoint.go
+++ b/prudp_endpoint.go
@@ -527,6 +527,8 @@ func (pep *PRUDPEndPoint) handleReliable(packet PRUDPPacketInterface) {
 	connection := packet.Sender().(*PRUDPConnection)
 
 	slidingWindow := packet.Sender().(*PRUDPConnection).SlidingWindow(packet.SubstreamID())
+	slidingWindow.Lock()
+	defer slidingWindow.Unlock()
 
 	for _, pendingPacket := range slidingWindow.Update(packet) {
 		if packet.Type() == constants.DataPacket {


### PR DESCRIPTION
<!--
* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
-->

Resolves problem discussed in  #48 

### Changes:

As discussed in #48 there is an intermittent issue which was causing messages to go unprocessed. This manifested in a few ways:

1. A `SlidingWindow` instance would have extra payloads added to its buffer, which would cause RMC decoding to fail, resulting in an unprocessed message
2. A `SlidingWindow` instance could end up with its cipher stream in a bad state because of multiple packets being added to it. In this case the rest of the messages in that connection would become corrupted as the client and server ciphers are out of sync

This fix adds a `sync.Mutex` to `SlidingWindow` and methods to lock and unlock the `SlidingWindow` instance. These are then used to lock the connection's sliding window for the duration of a call to `handleReliable`

This is crude but works as far as I can tell. I tested this with a simple RMC server setup and automated thousands of requests against it. Because we're now locking where we weren't before in the testing I did there was a performance difference, each run of 10k sequential requests (acks for each request were awaited before the next request was sent) took 16.5~ seconds on my machine. With the change this went up to about 16.8~ on average

I definitely don't think this is a perfect solution, or the cleanest but is probably an improvement on what is there

Happy for this to just be used as the basis for something much better!

<!--
* Describe your changes in as much detail as possible. Make sure to list your changes, as well as the rationale behind them.
* If applicable, include code snippets, images, videos, etc.
-->

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [x] What I'm implementing was an [approved issue](https://github.com/PretendoNetwork/Pretendo/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.