### PR TITLE
Prevent multi-fragment messages being lost

### DIFF
--- a/prudp_endpoint.go
+++ b/prudp_endpoint.go
@@ -531,10 +531,10 @@ func (pep *PRUDPEndPoint) handleReliable(packet PRUDPPacketInterface) {
 	defer slidingWindow.Unlock()
 
 	for _, pendingPacket := range slidingWindow.Update(packet) {
-		if packet.Type() == constants.DataPacket {
+		if pendingPacket.Type() == constants.DataPacket {
 			var decryptedPayload []byte
 
-			if packet.Version() != 2 {
+			if pendingPacket.Version() != 2 {
 				decryptedPayload = pendingPacket.decryptPayload()
 			} else {
 				// * PRUDPLite does not encrypt payloads
@@ -548,7 +548,7 @@ func (pep *PRUDPEndPoint) handleReliable(packet PRUDPPacketInterface) {
 
 			payload := slidingWindow.AddFragment(decompressedPayload)
 
-			if packet.getFragmentID() == 0 {
+			if pendingPacket.getFragmentID() == 0 {
 				message := NewRMCMessage(pep)
 				err := message.FromBytes(payload)
 				if err != nil {
@@ -558,9 +558,9 @@ func (pep *PRUDPEndPoint) handleReliable(packet PRUDPPacketInterface) {
 
 				slidingWindow.ResetFragmentedPayload()
 
-				packet.SetRMCMessage(message)
+				pendingPacket.SetRMCMessage(message)
 
-				pep.emit("data", packet)
+				pep.emit("data", pendingPacket)
 			}
 		}
 	}


### PR DESCRIPTION
<!--
* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
-->

Resolves some of the issues in: #53

### Changes:

When handling fragmented messages we check the fragment id of the wrong packet in `handleReliable` which results in an issue where if we receive the last packet of a fragmented message before we receive one of the other packets, the message will be lost

This is fixed by checking the fragment id of the `pendingPacket` when iterating the packets to update, rather than the specific packet that is being processed by the connection at that time

Discussed with @jonbarrow and agreed that everywhere within the loop which processes these pending packets should actually use `pendingPacket` instead of `packet` too. I've done this too

<!--
* Describe your changes in as much detail as possible. Make sure to list your changes, as well as the rationale behind them.
* If applicable, include code snippets, images, videos, etc.
-->

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [x] What I'm implementing was an [approved issue](https://github.com/PretendoNetwork/Pretendo/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.