### PR TITLE
Make reliable ping packets update sliding window

### DIFF
--- a/prudp_endpoint.go
+++ b/prudp_endpoint.go
@@ -421,6 +421,14 @@ func (pep *PRUDPEndPoint) handlePing(packet PRUDPPacketInterface) {
 	if packet.HasFlag(constants.PacketFlagNeedsAck) {
 		pep.acknowledgePacket(packet)
 	}
+
+	if packet.HasFlag(constants.PacketFlagReliable) {
+		connection := packet.Sender().(*PRUDPConnection)
+		slidingWindow := connection.SlidingWindow(packet.SubstreamID())
+		slidingWindow.Lock()
+		defer slidingWindow.Unlock()
+		slidingWindow.Update(packet)
+	}
 }
 
 func (pep *PRUDPEndPoint) readKerberosTicket(payload []byte) ([]byte, *types.PID, uint32, error) {


### PR DESCRIPTION
<!--
* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
-->

Resolves some of the issues in: #54, I believe this also fixes PretendoNetwork/friends#16

### Changes:

NintendoClients does a couple of interesting things with ping packets:
- It continues to send them even if the connection is actively being used
- It sets the `RELIABLE` flag on ping packets

Currently, we assume that all ping packets will be unreliable and so don't increment the expected sequence id from an incoming ping packet. This results in the sliding window of that substream waiting forever for a packet that will never come. This doesn't close the connection as we do acknowledge the ping, but means that any requests waiting for a response on that sliding window will never receive them

The fix updates the ping handler to check if a ping packet is reliable, and if so it increments the expected sequence id counter for that substream

#### Extra elaboration on PretendoNetwork/friends#16

In some of the images shared you can see the ping packet in WireShark before issues with the connection.

Also in the issue it's mentioned that things work for about 5/6 seconds (which is the [default ping timeout](https://github.com/kinnay/NintendoClients/blob/master/nintendo/files/config/default.cfg#L19)), and setting the pingtimeout to a large number is a workaround

As stated above, nintendoclients sends ping packets even if a connection is in use, so even if it's used constantly it'll eventually see this issue

<!--
* Describe your changes in as much detail as possible. Make sure to list your changes, as well as the rationale behind them.
* If applicable, include code snippets, images, videos, etc.
-->

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [x] What I'm implementing was an [approved issue](https://github.com/PretendoNetwork/Pretendo/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.