### PR TITLE
Prevent ping ACKs from affecting reliable packets

### DIFF
--- a/prudp_endpoint.go
+++ b/prudp_endpoint.go
@@ -153,8 +153,10 @@ func (pep *PRUDPEndPoint) handleAcknowledgment(packet PRUDPPacketInterface) {
 		return
 	}
 
-	slidingWindow := connection.SlidingWindow(packet.SubstreamID())
-	slidingWindow.ResendScheduler.AcknowledgePacket(packet.SequenceID())
+	if packet.HasFlag(constants.PacketFlagReliable) {
+		slidingWindow := connection.SlidingWindow(packet.SubstreamID())
+		slidingWindow.ResendScheduler.AcknowledgePacket(packet.SequenceID())
+	}
 }
 
 func (pep *PRUDPEndPoint) handleMultiAcknowledgment(packet PRUDPPacketInterface) {


### PR DESCRIPTION
<!--

* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
*
* CHECK https://github.com/PretendoNetwork/REPO_NAME/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved
* FOR APPROVED ISSUES!

-->

Resolves #61 

### Changes:

Adds a check to `handleAcknowledgement` in `PRUDPEndpoint` to prevent ping packets from acknowledging reliable packets with the same sequence ID

I'm unsure if any clients would ack ping packets as part of an aggregate acknowledgement, if they do, this fix won't work in those cases. I think for aggregate acknowledgements it's actually impossible to solve this with a separate sequnce counter for ping packets. Perhaps this is why nintendoclients sends ping packets as reliable and therefore uses sequence ids from that stream which would not interfere with other reliable packets?

<!--

* Describe your changes in as much detail as possible. Make sure to list your changes, as well as the rationale behind them.
* If applicable, include code snippets, images, videos, etc.
*
* If your changes require any database migrations, describe them in detail and leave any migration queries inside of a code
* block within a <details> tag.

-->

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [x] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.