### PR TITLE
Sync outgoing fragmented packets

### DIFF
--- a/prudp_server.go
+++ b/prudp_server.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"runtime"
+	"time"
 
 	"github.com/PretendoNetwork/nex-go/v2/constants"
 	"github.com/lxzan/gws"
@@ -222,6 +223,14 @@ func (ps *PRUDPServer) Send(packet PacketInterface) {
 			}
 
 			ps.sendPacket(packet)
+
+			// * This delay is here to prevent the server from overloading the client with too many packets.
+			// * The 16ms (1/60th of a second) value is chosen based on testing with the friends server and is a good balance between
+			// * Not being too slow and also not dropping any packets because we've overloaded the client. This may be because it
+			// * roughly matches the framerate that most games target (60fps)
+			if i < fragments {
+				time.Sleep(16 * time.Millisecond)
+			}
 		}
 	}
 }


### PR DESCRIPTION
<!--

* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
*
* CHECK https://github.com/PretendoNetwork/REPO_NAME/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved
* FOR APPROVED ISSUES!

-->

Resolves #66 

### Changes:

This addresses the issues discussed in #66 by adding a 16ms delay between fragmented data packets. This value was chosen as 16ms is roughly equivalent  to 1/60th of a second which is the refresh rate of many games. The intention was that if the networking code in the games is polling at that frequency we'd keep in sync with them, not overflowing the client's internal buffer.

I did try other values for this, going as low as 7ms and as high as 32ms but decided against it because:
- For longer delays, the overall times to send the packets were increased
- For shorter delays, occasionally packets were overflowing the queue resulting in the packet loss we want to avoid

There is potentially more that we could do here to make this smarter, but this drastically improves performance for large responses to the client. In the example `update_and_get_all_information` call with 100 friends. This speed up the response from 18 seconds to 2 seconds.

<!--

* Describe your changes in as much detail as possible. Make sure to list your changes, as well as the rationale behind them.
* If applicable, include code snippets, images, videos, etc.
*
* If your changes require any database migrations, describe them in detail and leave any migration queries inside of a code
* block within a <details> tag.

-->

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [x] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.