### PR TITLE
Fix bugs from recent performance enhancements 

### DIFF
--- a/kerberos.go
+++ b/kerberos.go
@@ -191,13 +191,15 @@ func NewKerberosTicketInternalData(server *PRUDPServer) *KerberosTicketInternalD
 
 // DeriveKerberosKey derives a users kerberos encryption key based on their PID and password
 func DeriveKerberosKey(pid *types.PID, password []byte) []byte {
-	iterationCount := 65000 + pid.Value()%1024
+	iterationCount := int(65000 + pid.Value()%1024)
 	key := make([]byte, md5.Size)
 	copy(key, password)
 
-	var i uint64 = 0
-	for ; i < iterationCount; i++ {
-		hash := md5.Sum(key)
+	hash := md5.Sum(password)
+	copy(key, hash[:])
+
+	for i := 1; i < iterationCount; i++ {
+		hash = md5.Sum(key)
 		copy(key, hash[:])
 	}
 

--- a/kerberos_test.go
+++ b/kerberos_test.go
@@ -1,0 +1,16 @@
+package nex
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeriveGuestKey(t *testing.T) {
+	pid := types.NewPID(100)
+	password := []byte("MMQea3n!fsik")
+	result := DeriveKerberosKey(pid, password)
+	assert.Equal(t, "9ef318f0a170fb46aab595bf9644f9e1", hex.EncodeToString(result))
+}

--- a/prudp_server.go
+++ b/prudp_server.go
@@ -82,7 +82,8 @@ func (ps *PRUDPServer) listenDatagram(quit chan struct{}) {
 
 		read, addr, err = ps.udpSocket.ReadFromUDP(buffer)
 		if err == nil {
-			packetData := buffer[:read]
+			packetData := make([]byte, read)
+			copy(packetData, buffer[:read])
 
 			err = ps.handleSocketMessage(packetData, addr, nil)
 		}


### PR DESCRIPTION
<!--

* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
*
* CHECK https://github.com/PretendoNetwork/REPO_NAME/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved
* FOR APPROVED ISSUES!

-->

### Changes:

As a result of #69 there were some regressions that this PR fixes while maintaining major performance improvements.

1. One of the changes in the previous PR stopped us from allocating 64 bytes every time we read in a new packet. Unfortunately, that state is later used in other goroutines as various `[]byte`s are stored on the packet that point to the underlying byte array. This PR instead allocates 64 bytes for the workers which read from the UDP stream, but then allocates just enough memory for each packet and copies the read bytes over.

2. A change to `DeriveKerberosKey` resulted in a regression for passwords shorter than 16 bytes. While almost all account passwords are 16 bytes as they are generated, the guest key which is hard coded in all NEX consoles uses a 12 byte key. This resulted in people who had not connected to the network before being unable to decrypt the kerberos key and failing to connect. This fix correctly initialises keys for passwords shorter than 16 bytes while retaining all of the performance benefits of the change. I've also added a test to make sure the guest key is generated properly

<!--

* Describe your changes in as much detail as possible. Make sure to list your changes, as well as the rationale behind them.
* If applicable, include code snippets, images, videos, etc.
*
* If your changes require any database migrations, describe them in detail and leave any migration queries inside of a code
* block within a <details> tag.

-->

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [x] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.