### PR TITLE
Remove Connection tracking from SocketConnection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ go.work.sum
 
 # custom
 .vscode
+.idea
 .env
 build
 log

--- a/prudp_connection.go
+++ b/prudp_connection.go
@@ -86,16 +86,7 @@ func (pc *PRUDPConnection) cleanup() {
 
 	pc.stopHeartbeatTimers()
 
-	pc.Socket.Connections.Delete(pc.SessionID)
-
 	pc.endpoint.emitConnectionEnded(pc)
-
-	if pc.Socket.Connections.Size() == 0 {
-		// * No more PRUDP connections, assume the socket connection is also closed
-		pc.endpoint.Server.Connections.Delete(pc.Socket.Address.String())
-		// TODO - Is there any other cleanup that needs to happen here?
-		// TODO - Should we add an event for when a socket closes too?
-	}
 }
 
 // InitializeSlidingWindows initializes the SlidingWindows for all substreams

--- a/prudp_server.go
+++ b/prudp_server.go
@@ -17,7 +17,6 @@ type PRUDPServer struct {
 	udpSocket                     *net.UDPConn
 	websocketServer               *WebSocketServer
 	Endpoints                     *MutexMap[uint8, *PRUDPEndPoint]
-	Connections                   *MutexMap[string, *SocketConnection]
 	SupportedFunctions            uint32
 	AccessKey                     string
 	KerberosTicketVersion         int
@@ -194,13 +193,7 @@ func (ps *PRUDPServer) processPacket(packet PRUDPPacketInterface, address net.Ad
 		return
 	}
 
-	discriminator := address.String()
-	socket, ok := ps.Connections.Get(discriminator)
-	if !ok {
-		socket = NewSocketConnection(ps, address, webSocketConnection)
-		ps.Connections.Set(discriminator, socket)
-	}
-
+	socket := NewSocketConnection(ps, address, webSocketConnection)
 	endpoint.processPacket(packet, socket)
 }
 
@@ -338,7 +331,6 @@ func (ps *PRUDPServer) SetFragmentSize(fragmentSize int) {
 func NewPRUDPServer() *PRUDPServer {
 	return &PRUDPServer{
 		Endpoints:          NewMutexMap[uint8, *PRUDPEndPoint](),
-		Connections:        NewMutexMap[string, *SocketConnection](),
 		SessionKeyLength:   32,
 		FragmentSize:       1300,
 		LibraryVersions:    NewLibraryVersions(),

--- a/socket_connection.go
+++ b/socket_connection.go
@@ -9,10 +9,9 @@ import (
 // SocketConnection represents a single open socket.
 // A single socket may have many PRUDP connections open on it.
 type SocketConnection struct {
-	Server              *PRUDPServer                       // * PRUDP server the socket is connected to
-	Address             net.Addr                           // * Sockets address
-	WebSocketConnection *gws.Conn                          // * Only used in PRUDPLite
-	Connections         *MutexMap[uint8, *PRUDPConnection] // * Open PRUDP connections separated by rdv::Stream ID, also called "port number"
+	Server              *PRUDPServer // * PRUDP server the socket is connected to
+	Address             net.Addr     // * Sockets address
+	WebSocketConnection *gws.Conn    // * Only used in PRUDPLite
 }
 
 // NewSocketConnection creates a new SocketConnection
@@ -21,6 +20,5 @@ func NewSocketConnection(server *PRUDPServer, address net.Addr, webSocketConnect
 		Server:              server,
 		Address:             address,
 		WebSocketConnection: webSocketConnection,
-		Connections:         NewMutexMap[uint8, *PRUDPConnection](),
 	}
 }


### PR DESCRIPTION
<!--

* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
*
* CHECK https://github.com/PretendoNetwork/REPO_NAME/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved
* FOR APPROVED ISSUES!

-->

Resolves #XXX

### Changes:

<!--

* Describe your changes in as much detail as possible. Make sure to list your changes, as well as the rationale behind them.
* If applicable, include code snippets, images, videos, etc.
*
* If your changes require any database migrations, describe them in detail and leave any migration queries inside of a code
* block within a <details> tag.

-->

Every SocketConnection had a map of *PRUDPConnection, which was never actually inserted into anywhere, so the intended function of tracking what OS sockets have which PRUDP streams was not being done.

Remove it as dead code. If the rest of the connection tracking is going to be implemented, this commit can be reverted.

Since the SocketConnection no longer has long-lived state in it, also remove the map on PRUDPServer and just create it as a simple data structure when needed.

The connection close handling of the websocket server had to be rewritten - the old code would never do anything due to the empty maps, so this can't be *worse* than nothing :)

Compile-tested, but I've only got a laptop so I need someone to smoketest it in practice.

- [X] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [X] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [ ] I have tested all of my changes.