### PR TITLE
More consistent connection cleanup

### DIFF
--- a/prudp_connection.go
+++ b/prudp_connection.go
@@ -261,9 +261,7 @@ func (pc *PRUDPConnection) startHeartbeat() {
 		// * If the heartbeat still did not restart, assume the
 		// * connection is dead and clean up
 		pc.pingKickTimer = time.AfterFunc(maxSilenceTime, func() {
-			pc.cleanup() // * "removed" event is dispatched here
-
-			endpoint.deleteConnectionByID(pc.ID)
+			endpoint.cleanupConnection(pc)
 		})
 	})
 }

--- a/prudp_endpoint.go
+++ b/prudp_endpoint.go
@@ -708,7 +708,7 @@ func (pep *PRUDPEndPoint) FindConnectionByPID(pid uint64) *PRUDPConnection {
 	var connection *PRUDPConnection
 
 	pep.Connections.Each(func(discriminator string, pc *PRUDPConnection) bool {
-		if pc.pid.Value() == pid {
+		if pc.pid.Value() == pid && pc.ConnectionState == StateConnected {
 			connection = pc
 			return true
 		}

--- a/prudp_endpoint.go
+++ b/prudp_endpoint.go
@@ -105,11 +105,24 @@ func (pep *PRUDPEndPoint) EmitError(err *Error) {
 	}
 }
 
-// deleteConnectionByID deletes the connection with the specified ID
-func (pep *PRUDPEndPoint) deleteConnectionByID(cid uint32) {
-	pep.Connections.DeleteIf(func(key string, value *PRUDPConnection) bool {
-		return value.ID == cid
+// cleanupConnection cleans up and deletes a connection from this endpoint. Will lock the Connections mutex - make sure
+// you don't hold it during a call, or this will deadlock
+func (pep *PRUDPEndPoint) cleanupConnection(connection *PRUDPConnection) {
+	discriminator := fmt.Sprintf("%s-%d-%d", connection.Socket.Address.String(), connection.StreamType, connection.StreamID)
+
+	found := false
+	pep.Connections.RunAndDelete(discriminator, func(key string, conn *PRUDPConnection) {
+		found = true
 	})
+
+	// * Probably this connection is on a different PRUDPEndPoint
+	if !found {
+		logger.Warningf("Tried to delete connection %v (ID %v) but it doesn't exist!", discriminator, connection.ID)
+	}
+
+	// * We can't do this during RunAndDelete, since we hold the Connections mutex then
+	// * This way we avoid any recursive locking
+	connection.cleanup()
 }
 
 func (pep *PRUDPEndPoint) processPacket(packet PRUDPPacketInterface, socket *SocketConnection) {
@@ -417,10 +430,7 @@ func (pep *PRUDPEndPoint) handleDisconnect(packet PRUDPPacketInterface) {
 	streamID := packet.SourceVirtualPortStreamID()
 	discriminator := fmt.Sprintf("%s-%d-%d", packet.Sender().Address().String(), streamType, streamID)
 	if connection, ok := pep.Connections.Get(discriminator); ok {
-		// * We make sure to update the connection state here because we could still be attempting to
-		// * resend packets.
-		connection.cleanup()
-		pep.Connections.Delete(discriminator)
+		pep.cleanupConnection(connection)
 	}
 
 	pep.emit("disconnect", packet)

--- a/timeout_manager.go
+++ b/timeout_manager.go
@@ -53,10 +53,10 @@ func (tm *TimeoutManager) start(packet PRUDPPacketInterface) {
 	}
 
 	if tm.packets.Has(packet.SequenceID()) {
+		endpoint := packet.Sender().Endpoint().(*PRUDPEndPoint)
+
 		// * This is `<` instead of `<=` for accuracy with observed behavior, even though we're comparing send count vs _resend_ max
 		if packet.SendCount() < tm.streamSettings.MaxPacketRetransmissions {
-			endpoint := packet.Sender().Endpoint().(*PRUDPEndPoint)
-
 			packet.incrementSendCount()
 			packet.setSentAt(time.Now())
 			rto := endpoint.ComputeRetransmitTimeout(packet)
@@ -76,9 +76,7 @@ func (tm *TimeoutManager) start(packet PRUDPPacketInterface) {
 			server.sendRaw(connection.Socket, data)
 		} else {
 			// * Packet has been retried too many times, consider the connection dead
-			connection.Lock()
-			defer connection.Unlock()
-			connection.cleanup()
+			endpoint.cleanupConnection(connection)
 		}
 	}
 }

--- a/websocket_server.go
+++ b/websocket_server.go
@@ -22,25 +22,26 @@ func (wseh *wsEventHandler) OnOpen(socket *gws.Conn) {
 }
 
 func (wseh *wsEventHandler) OnClose(wsConn *gws.Conn, _ error) {
-	connections := make([]*PRUDPConnection, 0)
-
 	// * Loop over all connections on all endpoints
 	wseh.prudpServer.Endpoints.Each(func(streamid uint8, pep *PRUDPEndPoint) bool {
-		return pep.Connections.Each(func(discriminator string, pc *PRUDPConnection) bool {
+		connections := make([]*PRUDPConnection, 0)
+
+		pep.Connections.Each(func(discriminator string, pc *PRUDPConnection) bool {
 			if pc.Socket.Address == wsConn.RemoteAddr() {
 				connections = append(connections, pc)
 			}
 			return false
 		})
-	})
 
-	// * We cannot modify a MutexMap while looping over it
-	// * since the mutex is locked. We first need to grab
-	// * the entries we want to delete, and then loop over
-	// * them here to actually clean them up
-	for _, connection := range connections {
-		connection.cleanup() // * "removed" event is dispatched here
-	}
+		// * We cannot modify a MutexMap while looping over it
+		// * since the mutex is locked. We first need to grab
+		// * the entries we want to delete, and then loop over
+		// * them here to actually clean them up
+		for _, connection := range connections {
+			pep.cleanupConnection(connection) // * "removed" event is dispatched here
+		}
+		return false
+	})
 }
 
 func (wseh *wsEventHandler) OnPing(socket *gws.Conn, payload []byte) {


### PR DESCRIPTION
<!--

* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
*
* CHECK https://github.com/PretendoNetwork/REPO_NAME/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved
* FOR APPROVED ISSUES!

-->

Partially helps with #52 

### Changes:

<!--

* Describe your changes in as much detail as possible. Make sure to list your changes, as well as the rationale behind them.
* If applicable, include code snippets, images, videos, etc.
*
* If your changes require any database migrations, describe them in detail and leave any migration queries inside of a code
* block within a <details> tag.

-->

This PR centralizes all cleanup of PRUDPConnection into a single function, `cleanupConnectionByID`. This ensures that all necessary steps are taken to cleanup connections and remove them from the endpoint's Connections map, and we are consistent with things like map keys (though this particular implementation doesn't rely on knowing the map key). There were a few callsites previously that were calling `.cleanup` and *not* removing them from the map.

The only big caveat with this approach is that the Connections mutex can't be held at the time of cleanup. I do NOT take PRUDPConnection.mutex - this may be needed?

It's worth noting that all callsites have a full PRUDPConnection*, so maybe this map datastructure is not the most efficient. This can be looked into later.

Also a bonus fix to make FindConnectionByPID actually check its expected invariant (StateConnected has a PID, other states have no PID), which makes it a bit more resilient to this style of bug, should it appear in the future.

Currently under test with Minecraft: Wii U Edition on prod, using [additional self-testing code to detect invariant violations](https://github.com/PretendoNetwork/minecraft-wiiu/tree/work/adp-debugging) with no issues detected after two days. The connection count has been steadily increasing without plateau'ing off, so there might still be some source of stale connections elsewhere in the code, but these ones genuinely do seem harmless.

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [x] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.