### PR TITLE
Implement token authentication field on account structure

### DIFF
--- a/account.go
+++ b/account.go
@@ -10,18 +10,20 @@ import "github.com/PretendoNetwork/nex-go/v2/types"
 // guest account, an account which represents the authentication server, and one which represents
 // the secure server. See https://nintendo-wiki.pretendo.network/docs/nex/kerberos for more information.
 type Account struct {
-	PID      types.PID // * The PID of the account. PIDs are unique IDs per account. NEX PIDs start at 1800000000 and decrement with each new account.
-	Username string    // * The username for the account. For NEX user accounts this is the same as the accounts PID.
-	Password string    // * The password for the account. For NEX accounts this is always 16 characters long using seemingly any ASCII character
+	PID               types.PID // * The PID of the account. PIDs are unique IDs per account. NEX PIDs start at 1800000000 and decrement with each new account.
+	Username          string    // * The username for the account. For NEX user accounts this is the same as the accounts PID.
+	Password          string    // * The password for the account. For NEX accounts this is always 16 characters long using seemingly any ASCII character.
+	RequiresTokenAuth bool      // * If the account requires token authentication. Always false for special accounts or user accounts pre-Switch.
 }
 
 // NewAccount returns a new instance of Account.
 // This does not register an account, only creates a new
 // struct instance.
-func NewAccount(pid types.PID, username, password string) *Account {
+func NewAccount(pid types.PID, username, password string, requiresTokenAuth bool) *Account {
 	return &Account{
-		PID:      pid,
-		Username: username,
-		Password: password,
+		PID:               pid,
+		Username:          username,
+		Password:          password,
+		RequiresTokenAuth: requiresTokenAuth,
 	}
 }

--- a/test/main.go
+++ b/test/main.go
@@ -46,9 +46,9 @@ func accountDetailsByUsername(username string) (*nex.Account, *nex.Error) {
 }
 
 func main() {
-	authenticationServerAccount = nex.NewAccount(types.NewPID(1), "Quazal Authentication", "authpassword")
-	secureServerAccount = nex.NewAccount(types.NewPID(2), "Quazal Rendez-Vous", "securepassword")
-	testUserAccount = nex.NewAccount(types.NewPID(1800000000), "1800000000", "nexuserpassword")
+	authenticationServerAccount = nex.NewAccount(types.NewPID(1), "Quazal Authentication", "authpassword", false)
+	secureServerAccount = nex.NewAccount(types.NewPID(2), "Quazal Rendez-Vous", "securepassword", false)
+	testUserAccount = nex.NewAccount(types.NewPID(1800000000), "1800000000", "nexuserpassword", false)
 
 	wg.Add(3)
 


### PR DESCRIPTION
Resolves #XXX

### Changes:

Updates the account structure to have a new field called RequiresTokenAuth, which should be true on user accounts that do not have an exposed NEX password and instead rely on token authentication. This is used in https://github.com/PretendoNetwork/nex-protocols-common-go/pull/56

(Note: this change is breaking but is a very simple fix, as it only requires adding a "false" to the end of 2 references to the same function per server)

- [X] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [X] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [X] I have tested all of my changes.