### PR TITLE
Remove websocket timeouts

### DIFF
--- a/websocket_server.go
+++ b/websocket_server.go
@@ -3,22 +3,21 @@ package nex
 import (
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/lxzan/gws"
 )
 
-const (
-	pingInterval = 5 * time.Second
-	pingWait     = 10 * time.Second
-)
+// const (
+// 	pingInterval = 5 * time.Second
+// 	pingWait     = 10 * time.Second
+// )
 
 type wsEventHandler struct {
 	prudpServer *PRUDPServer
 }
 
 func (wseh *wsEventHandler) OnOpen(socket *gws.Conn) {
-	_ = socket.SetDeadline(time.Now().Add(pingInterval + pingWait))
+	// _ = socket.SetDeadline(time.Now().Add(pingInterval + pingWait))
 }
 
 func (wseh *wsEventHandler) OnClose(wsConn *gws.Conn, _ error) {
@@ -45,8 +44,8 @@ func (wseh *wsEventHandler) OnClose(wsConn *gws.Conn, _ error) {
 }
 
 func (wseh *wsEventHandler) OnPing(socket *gws.Conn, payload []byte) {
-	_ = socket.SetDeadline(time.Now().Add(pingInterval + pingWait))
-	_ = socket.WritePong(nil)
+	//_ = socket.SetDeadline(time.Now().Add(pingInterval + pingWait))
+	//_ = socket.WritePong(nil)
 }
 
 func (wseh *wsEventHandler) OnPong(socket *gws.Conn, payload []byte) {}


### PR DESCRIPTION
Remove websocket timeouts in the wrapper, as PRUDPLite handles pings at the PRUDP layer, not the websocket layer

- [X] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [X] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [ ] I have tested all of my changes.