### PR TITLE
Add `EnableBasicUDPHealthCheck`

### DIFF
--- a/prudp_server.go
+++ b/prudp_server.go
@@ -32,8 +32,6 @@ func EnableBasicUDPHealthCheck(port int) {
 		panic(err)
 	}
 
-	quit := make(chan struct{})
-
 	for i := 0; i < runtime.NumCPU(); i++ {
 		go func() {
 			buffer := make([]byte, 1024)
@@ -46,8 +44,6 @@ func EnableBasicUDPHealthCheck(port int) {
 			}
 		}()
 	}
-
-	<-quit
 }
 
 // PRUDPServer represents a bare-bones PRUDP server

--- a/prudp_server.go
+++ b/prudp_server.go
@@ -18,6 +18,38 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
+// EnableBasicUDPHealthCheck enables a basic UDP echo server
+// on the given port, used to check if the server is reachable
+// at all
+func EnableBasicUDPHealthCheck(port int) {
+	udpAddress, err := net.ResolveUDPAddr("udp", fmt.Sprintf(":%d", port))
+	if err != nil {
+		panic(err)
+	}
+
+	socket, err := net.ListenUDP("udp", udpAddress)
+	if err != nil {
+		panic(err)
+	}
+
+	quit := make(chan struct{})
+
+	for i := 0; i < runtime.NumCPU(); i++ {
+		go func() {
+			buffer := make([]byte, 1024)
+
+			for {
+				n, clientAddr, err := socket.ReadFromUDP(buffer)
+				if err == nil {
+					socket.WriteToUDP(buffer[:n], clientAddr)
+				}
+			}
+		}()
+	}
+
+	<-quit
+}
+
 // PRUDPServer represents a bare-bones PRUDP server
 type PRUDPServer struct {
 	udpSocket                     *net.UDPConn


### PR DESCRIPTION
Resolves #XXX

### Changes:

Adds a `nex.EnableBasicUDPHealthCheck()` function to the package global. This just spawns a super basic UDP echo server, which can be used to check if a server is reachable at all

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [ ] I have tested all of my changes.