### PR TITLE
fix: support numeric() on all integer types

### DIFF
--- a/types/int16.go
+++ b/types/int16.go
@@ -69,8 +69,15 @@ func (i16 *Int16) Scan(value any) error {
 	switch v := value.(type) {
 	case int64:
 		*i16 = Int16(v)
-	case string:
-		parsed, err := strconv.ParseInt(v, 10, 16)
+	case []byte, string:
+		var str string
+		if b, ok := v.([]byte); ok {
+			str = string(b)
+		} else {
+			str = v.(string)
+		}
+
+		parsed, err := strconv.ParseInt(str, 10, 16)
 		if err != nil {
 			return fmt.Errorf("cannot parse string %q into Int16: %w", v, err)
 		}

--- a/types/int32.go
+++ b/types/int32.go
@@ -69,8 +69,15 @@ func (i32 *Int32) Scan(value any) error {
 	switch v := value.(type) {
 	case int64:
 		*i32 = Int32(v)
-	case string:
-		parsed, err := strconv.ParseInt(v, 10, 32)
+	case []byte, string:
+		var str string
+		if b, ok := v.([]byte); ok {
+			str = string(b)
+		} else {
+			str = v.(string)
+		}
+
+		parsed, err := strconv.ParseInt(str, 10, 32)
 		if err != nil {
 			return fmt.Errorf("cannot parse string %q into Int32: %w", v, err)
 		}

--- a/types/int64.go
+++ b/types/int64.go
@@ -69,8 +69,15 @@ func (i64 *Int64) Scan(value any) error {
 	switch v := value.(type) {
 	case int64:
 		*i64 = Int64(v)
-	case string:
-		parsed, err := strconv.ParseInt(v, 10, 64)
+	case []byte, string:
+		var str string
+		if b, ok := v.([]byte); ok {
+			str = string(b)
+		} else {
+			str = v.(string)
+		}
+
+		parsed, err := strconv.ParseInt(str, 10, 64)
 		if err != nil {
 			return fmt.Errorf("cannot parse string %q into Int64: %w", v, err)
 		}

--- a/types/int8.go
+++ b/types/int8.go
@@ -69,8 +69,15 @@ func (i8 *Int8) Scan(value any) error {
 	switch v := value.(type) {
 	case int64:
 		*i8 = Int8(v)
-	case string:
-		parsed, err := strconv.ParseInt(v, 10, 8)
+	case []byte, string:
+		var str string
+		if b, ok := v.([]byte); ok {
+			str = string(b)
+		} else {
+			str = v.(string)
+		}
+
+		parsed, err := strconv.ParseInt(str, 10, 8)
 		if err != nil {
 			return fmt.Errorf("cannot parse string %q into Int8: %w", v, err)
 		}

--- a/types/uint16.go
+++ b/types/uint16.go
@@ -69,8 +69,15 @@ func (u16 *UInt16) Scan(value any) error {
 	switch v := value.(type) {
 	case int64:
 		*u16 = UInt16(v)
-	case string:
-		parsed, err := strconv.ParseUint(v, 10, 16)
+	case []byte, string:
+		var str string
+		if b, ok := v.([]byte); ok {
+			str = string(b)
+		} else {
+			str = v.(string)
+		}
+
+		parsed, err := strconv.ParseUint(str, 10, 16)
 		if err != nil {
 			return fmt.Errorf("cannot parse string %q into UInt16: %w", v, err)
 		}

--- a/types/uint32.go
+++ b/types/uint32.go
@@ -69,8 +69,15 @@ func (u32 *UInt32) Scan(value any) error {
 	switch v := value.(type) {
 	case int64:
 		*u32 = UInt32(v)
-	case string:
-		parsed, err := strconv.ParseUint(v, 10, 32)
+	case []byte, string:
+		var str string
+		if b, ok := v.([]byte); ok {
+			str = string(b)
+		} else {
+			str = v.(string)
+		}
+
+		parsed, err := strconv.ParseUint(str, 10, 32)
 		if err != nil {
 			return fmt.Errorf("cannot parse string %q into UInt32: %w", v, err)
 		}

--- a/types/uint8.go
+++ b/types/uint8.go
@@ -69,8 +69,15 @@ func (u8 *UInt8) Scan(value any) error {
 	switch v := value.(type) {
 	case int64:
 		*u8 = UInt8(v)
-	case string:
-		parsed, err := strconv.ParseUint(v, 10, 8)
+	case []byte, string:
+		var str string
+		if b, ok := v.([]byte); ok {
+			str = string(b)
+		} else {
+			str = v.(string)
+		}
+
+		parsed, err := strconv.ParseUint(str, 10, 8)
 		if err != nil {
 			return fmt.Errorf("cannot parse string %q into UInt8: %w", v, err)
 		}


### PR DESCRIPTION
### Changes:

For unsigned types in Postgres, we have to use oversized types since Postgres only has signed types natively. For example, `uint64` is usually stored as `numeric(20)`. For smaller types (e.g. `uint32`) the developer has a choice between the next integer up (`bigint`, 64-bit) or the numeric equivalent (`numeric(10)`).

In Scanner, integers come to us as strings, but numeric types come as byte slices. The `uint64` implementation already supported byte slices for numerics, but the other types omitted it. This PR adds that code to the other unsigned types, and also the signed types too since there's no reason to not allow using numeric there.

Bug impacts any game updated from pre-v2.2.0 and which uses `numeric` for `uint8`, `uint16` or `uint32`. Puyo Puyo Tetris is known to have been affected by this since the DataStore rework uses `numeric(10)` for uint32 in a few places.

`sql: Scan error on column index 2, name "size": cannot scan []uint8 into UInt32`

Other games will need to have their logs audited.

<!--

* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
*
* CHECK https://github.com/PretendoNetwork/REPO_NAME/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved
* FOR APPROVED ISSUES!

-->

<!--

* Describe your changes in as much detail as possible. Make sure to list your changes, as well as the rationale behind them.
* If applicable, include code snippets, images, videos, etc.
*
* If your changes require any database migrations, describe them in detail and leave any migration queries inside of a code
* block within a <details> tag.

-->

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.